### PR TITLE
Halo exchange functions with fields as parameter

### DIFF
--- a/src/auxiliary/logs.jl
+++ b/src/auxiliary/logs.jl
@@ -24,6 +24,13 @@ function init_logfile(options::AbstractOptions)
     return nothing
 end
 
+function add_to_logfile(options::AbstractOptions, msg::AbstractString)
+    open(options.logfile, "a") do io
+        write(io, msg)
+    end
+    return nothing
+end
+
 function get_logfile_head()
     msg = "LOGFILE CREATED ON "
     msg *= Dates.format(Dates.now(), "yyyy-mm-dd, HH:MM:SS")

--- a/src/core/halo_exchange.jl
+++ b/src/core/halo_exchange.jl
@@ -1,3 +1,11 @@
+struct HaloExchange
+    tag::Int
+    src_chunk_id::Int
+    dest_chunk_id::Int
+    src_idxs::Vector{Int}
+    dest_idxs::Vector{Int}
+end
+
 function exchange!(dest::Matrix{T}, src::Matrix{T}, dest_idxs::Vector{Int},
                    src_idxs::Vector{Int}) where {T}
     for i in eachindex(dest_idxs)

--- a/src/core/mpi_data_handler.jl
+++ b/src/core/mpi_data_handler.jl
@@ -212,14 +212,19 @@ end
 
 function exchange_loc_to_halo!(dh::MPIDataHandler, fields::NTuple{N,Symbol}) where {N}
     for field in fields
-        for (ex_id, ex) in enumerate(dh.lth_exs_send)
-            send_lth!(dh, ex, ex_id, field)
-        end
-        for (ex_id, ex) in enumerate(dh.lth_exs_recv)
-            recv_lth!(dh, ex, ex_id, field)
-        end
-        MPI.Waitall(get_lth_reqests(dh, field))
+        exchange_loc_to_halo!(dh, field)
     end
+    return nothing
+end
+
+function exchange_loc_to_halo!(dh::MPIDataHandler, field::Symbol)
+    for (ex_id, ex) in enumerate(dh.lth_exs_send)
+        send_lth!(dh, ex, ex_id, field)
+    end
+    for (ex_id, ex) in enumerate(dh.lth_exs_recv)
+        recv_lth!(dh, ex, ex_id, field)
+    end
+    MPI.Waitall(get_lth_reqests(dh, field))
     return nothing
 end
 
@@ -255,14 +260,19 @@ end
 
 function exchange_halo_to_loc!(dh::MPIDataHandler, fields::NTuple{N,Symbol}) where {N}
     for field in fields
-        for (ex_id, ex) in enumerate(dh.htl_exs_send)
-            send_htl!(dh, ex, ex_id, field)
-        end
-        for (ex_id, ex) in enumerate(dh.htl_exs_recv)
-            recv_htl!(dh, ex, ex_id, field)
-        end
-        MPI.Waitall(get_htl_reqests(dh, field))
+        exchange_halo_to_loc!(dh, field)
     end
+    return nothing
+end
+
+function exchange_halo_to_loc!(dh::MPIDataHandler, field::Symbol)
+    for (ex_id, ex) in enumerate(dh.htl_exs_send)
+        send_htl!(dh, ex, ex_id, field)
+    end
+    for (ex_id, ex) in enumerate(dh.htl_exs_recv)
+        recv_htl!(dh, ex, ex_id, field)
+    end
+    MPI.Waitall(get_htl_reqests(dh, field))
     return nothing
 end
 

--- a/src/core/mpi_data_handler.jl
+++ b/src/core/mpi_data_handler.jl
@@ -110,19 +110,19 @@ function get_all_point_ids(chunk::AbstractBodyChunk, n_points::Int)
 end
 
 function find_halo_exchange_bufs(chunk::AbstractBodyChunk, halo_infos::MPIHaloInfo)
-    has_read = has_read_halos(chunk)
-    has_write = has_write_halos(chunk)
+    has_read = has_loc_to_halo_exs(chunk)
+    has_write = has_halo_to_loc_exs(chunk)
     read_hexs, write_hexs = _find_halo_exchange_bufs(chunk, halo_infos, has_read, has_write)
     return read_hexs, write_hexs
 end
 
-function has_read_halos(chunk::AbstractBodyChunk)
+function has_loc_to_halo_exs(chunk::AbstractBodyChunk)
     hrfs = halo_read_fields(chunk.storage)
     isempty(hrfs) && return false
     return true
 end
 
-function has_write_halos(chunk::AbstractBodyChunk)
+function has_halo_to_loc_exs(chunk::AbstractBodyChunk)
     hwfs = halo_write_fields(chunk.storage)
     isempty(hwfs) && return false
     return true
@@ -220,7 +220,7 @@ function calc_stable_timestep(dh::MPIDataHandler, safety_factor::Float64)
     return Δt * safety_factor
 end
 
-function exchange_read_fields!(dh::MPIDataHandler)
+function exchange_loc_to_halo!(dh::MPIDataHandler)
     for (hex_id, hex) in enumerate(dh.read_hexs_send)
         send_read_he!(dh, hex, hex_id)
     end
@@ -253,7 +253,7 @@ function recv_read_he!(dh::MPIDataHandler, he::HaloExchangeBuf)
     return nothing
 end
 
-function exchange_write_fields!(dh::MPIDataHandler)
+function exchange_halo_to_loc!(dh::MPIDataHandler)
     for (hex_id, hex) in enumerate(dh.write_hexs_send)
         send_write_he!(dh, hex, hex_id)
     end

--- a/src/core/mpi_data_handler.jl
+++ b/src/core/mpi_data_handler.jl
@@ -1,18 +1,3 @@
-struct HaloExchangeBuf{T,K}
-    n_fields::Int
-    src_chunk_id::Int
-    dest_chunk_id::Int
-    src_idxs::Vector{Int}
-    dest_idxs::Vector{Int}
-    bufs::T
-    tags::K
-    function HaloExchangeBuf(n::Int, src_chunk_id::Int, dest_chunk_id::Int,
-                             src_idxs::AbstractVector{Int}, dest_idxs::AbstractVector{Int},
-                             bufs::T, tags::K) where {T,K}
-        return new{T,K}(n, src_chunk_id, dest_chunk_id, src_idxs, dest_idxs, bufs, tags)
-    end
-end
-
 struct MPIHaloInfo
     point_ids::Dict{Int,Vector{Int}}
     halos_points::Dict{Int,Vector{Int}}
@@ -20,14 +5,20 @@ struct MPIHaloInfo
     hidxs_by_src::Dict{Int,Dict{Int,Vector{Int}}}
 end
 
-struct MPIDataHandler{C<:AbstractBodyChunk,RB,WB} <: AbstractMPIDataHandler
+struct MPIDataHandler{C<:AbstractBodyChunk,B} <: AbstractMPIDataHandler
     chunk::C
-    lth_exs_send::Vector{HaloExchangeBuf{RB}}
-    lth_exs_recv::Vector{HaloExchangeBuf{RB}}
-    htl_exs_send::Vector{HaloExchangeBuf{WB}}
-    htl_exs_recv::Vector{HaloExchangeBuf{WB}}
-    lth_reqs::Vector{MPI.Request}
-    htl_reqs::Vector{MPI.Request}
+    n_halo_fields::Int
+    lth_exs_send::Vector{HaloExchange}
+    lth_exs_recv::Vector{HaloExchange}
+    htl_exs_send::Vector{HaloExchange}
+    htl_exs_recv::Vector{HaloExchange}
+    lth_send_bufs::Vector{B}
+    lth_recv_bufs::Vector{B}
+    htl_send_bufs::Vector{B}
+    htl_recv_bufs::Vector{B}
+    field_to_buf::Dict{Symbol,Int}
+    lth_reqs::Vector{Vector{MPI.Request}}
+    htl_reqs::Vector{Vector{MPI.Request}}
 end
 
 function MPIDataHandler(body::AbstractBody, time_solver::AbstractTimeSolver,
@@ -42,13 +33,17 @@ function MPIDataHandler(body::AbstractBody, time_solver::AbstractTimeSolver,
     chunk = chop_body_mpi(body, time_solver, point_decomp, v)
     @timeit_debug TO "find halo exchanges" begin
         halo_infos = get_halo_infos(chunk, point_decomp, body.n_points)
-        lth_exs, htl_exs = find_halo_exchange_bufs(chunk, halo_infos)
-        lth_exs_send, lth_exs_recv = filter_send_recv(lth_exs)
-        htl_exs_send, htl_exs_recv = filter_send_recv(htl_exs)
-        lth_reqs, htl_reqs = init_reqs(lth_exs_send), init_reqs(htl_exs_send)
+        lth_exs, htl_exs = find_halo_exchanges(halo_infos)
+        lth_send, lth_recv = filter_send_recv(lth_exs)
+        htl_send, htl_recv = filter_send_recv(htl_exs)
+        bufs = find_bufs(chunk.storage, lth_send, lth_recv, htl_send, htl_recv)
+        n_halo_fields = get_n_halo_fields(chunk.storage)
+        lth_reqs = init_reqs(lth_send, n_halo_fields)
+        htl_reqs = init_reqs(htl_send, n_halo_fields)
     end
-    return MPIDataHandler(chunk, lth_exs_send, lth_exs_recv, htl_exs_send,
-                          htl_exs_recv, lth_reqs, htl_reqs)
+    mdh = MPIDataHandler(chunk, n_halo_fields, lth_send, lth_recv, htl_send, htl_recv,
+                         bufs..., lth_reqs, htl_reqs)
+    return mdh
 end
 
 function MPIDataHandler(multibody::AbstractMultibodySetup,
@@ -109,109 +104,97 @@ function get_all_point_ids(chunk::AbstractBodyChunk, n_points::Int)
     return all_point_ids
 end
 
-function find_halo_exchange_bufs(chunk::AbstractBodyChunk, halo_infos::MPIHaloInfo)
-    has_lth = has_lth_exs(chunk)
-    has_htl = has_htl_exs(chunk)
-    lth_exs, htl_exs = _find_halo_exchange_bufs(chunk, halo_infos, has_lth, has_htl)
-    return lth_exs, htl_exs
-end
-
-function has_lth_exs(chunk::AbstractBodyChunk)
-    hrfs = loc_to_halo_fields(chunk.storage)
-    isempty(hrfs) && return false
-    return true
-end
-
-function has_htl_exs(chunk::AbstractBodyChunk)
-    hwfs = halo_to_loc_fields(chunk.storage)
-    isempty(hwfs) && return false
-    return true
-end
-
-function _find_halo_exchange_bufs(chunk::AbstractBodyChunk, halo_info::MPIHaloInfo,
-                                  has_lth::Bool, has_htl::Bool)
-    RB = get_loc_to_halo_buftype(chunk.storage)
-    WB = get_halo_to_loc_buftype(chunk.storage)
-    lth_exs = Vector{HaloExchangeBuf{RB}}()
-    htl_exs = Vector{HaloExchangeBuf{WB}}()
+function find_halo_exchanges(halo_infos::MPIHaloInfo)
+    lth_exs = Vector{HaloExchange}()
+    htl_exs = Vector{HaloExchange}()
     ccid = mpi_chunk_id()
-    for (cid, hidxs_by_src) in halo_info.hidxs_by_src
+    for (cid, hidxs_by_src) in halo_infos.hidxs_by_src
         for (hcid, idxs) in hidxs_by_src
-            _find_hexs!(lth_exs, htl_exs, chunk, halo_info, ccid, cid, hcid, idxs,
-                        has_lth, has_htl)
+            _find_exs!(lth_exs, htl_exs, halo_infos, ccid, cid, hcid, idxs)
         end
     end
     return lth_exs, htl_exs
 end
 
-@inline function get_loc_to_halo_buftype(s::AbstractStorage)
-    return typeof(get_loc_to_halo_fields(s))
-end
-
-@inline function get_halo_to_loc_buftype(s::AbstractStorage)
-    return typeof(get_halo_to_loc_fields(s))
-end
-
-function _find_hexs!(rhexs::Vector, whexs::Vector, chunk::AbstractBodyChunk,
-                     hi::MPIHaloInfo, ccid::Int, cid::Int, hcid::Int, idxs::Vector{Int},
-                     has_lth::Bool, has_htl::Bool)
+function _find_exs!(lth_exs::Vector, htl_exs::Vector, hi::MPIHaloInfo, ccid::Int, cid::Int,
+                    hcid::Int, idxs::Vector{Int})
     (ccid == cid || ccid == hcid) || return nothing
     hidxs = hi.point_ids[cid][idxs]
     localize!(hidxs, hi.localizers[hcid])
-    if has_lth
-        bufs = get_loc_to_halo_bufs(chunk.storage, length(idxs))
-        tags = get_tags(bufs, cid * mpi_nranks())
-        n_fields = length(bufs)
-        hex = HaloExchangeBuf(n_fields, hcid, cid, hidxs, idxs, bufs, tags)
-        push!(rhexs, hex)
-    end
-    if has_htl
-        bufs = get_loc_to_halo_bufs(chunk.storage, length(idxs))
-        tags = get_tags(bufs, cid * mpi_nranks())
-        n_fields = length(bufs)
-        hex = HaloExchangeBuf(n_fields, cid, hcid, idxs, hidxs, bufs, tags)
-        push!(whexs, hex)
-    end
+    push!(lth_exs, HaloExchange(cid * mpi_nranks(), hcid, cid, hidxs, idxs))
+    push!(htl_exs, HaloExchange(cid * mpi_nranks(), cid, hcid, idxs, hidxs))
     return nothing
 end
 
-@inline function get_loc_to_halo_bufs(s::AbstractStorage, n_halo_points::Int)
-    return Tuple(get_buf(a, n_halo_points) for a in get_loc_to_halo_fields(s))
+function find_bufs(s::AbstractStorage, lth_exs_send::V, lth_exs_recv::V, htl_exs_send::V,
+                   htl_exs_recv::V) where {V<:Vector{HaloExchange}}
+    lth_send = [find_bufs(s, ex) for ex in lth_exs_send]
+    lth_recv = [find_bufs(s, ex) for ex in lth_exs_recv]
+    htl_send = [find_bufs(s, ex) for ex in htl_exs_send]
+    htl_recv = [find_bufs(s, ex) for ex in htl_exs_recv]
+    field_to_buf = find_field_to_buf(s)
+    return lth_send, lth_recv, htl_send, htl_recv, field_to_buf
 end
 
-@inline function get_halo_to_loc_bufs(s::AbstractStorage, n_halo_points::Int)
-    return Tuple(get_buf(a, n_halo_points) for a in get_halo_to_loc_fields(s))
+@inline function find_bufs(s::AbstractStorage, ex::HaloExchange)
+    return _find_bufs(s, length(ex.dest_idxs))
 end
 
-@inline get_buf(a::Matrix{T}, n::Int) where {T} = zeros(T, size(a, 1), n)
-@inline get_buf(::Vector{T}, n::Int) where {T} = zeros(T, n)
-
-@inline function get_tags(bufs, i)
-    return Tuple(i + j for j in eachindex(bufs))
+@inline function _find_bufs(s::AbstractStorage, n_halo_points::Int)
+    return Tuple(find_buf(a, n_halo_points) for a in get_halo_fields(s))
 end
 
-function filter_send_recv(hexs::Vector{HaloExchangeBuf{B}}) where {B}
-    send_hexs = Vector{HaloExchangeBuf{B}}()
-    recv_hexs = Vector{HaloExchangeBuf{B}}()
-    for hex in hexs
-        if mpi_chunk_id() == hex.src_chunk_id
-            push!(send_hexs, hex)
+@inline find_buf(a::Matrix{T}, n::Int) where {T} = zeros(T, size(a, 1), n)
+@inline find_buf(::Vector{T}, n::Int) where {T} = zeros(T, n)
+
+function find_field_to_buf(s::AbstractStorage)
+    fields = get_halo_fieldnames(s)
+    field_to_buf = Dict{Symbol,Int}()
+    for (i, field) in enumerate(fields)
+        field_to_buf[field] = i
+    end
+    return field_to_buf
+end
+
+@inline function get_buf(bufs::T, i::Int) where {T}
+    return _get_buf(bufs, Val(i))
+end
+
+@inline function _get_buf(bufs::T, ::Val{N}) where {T,N}
+    return bufs[N]
+end
+
+function filter_send_recv(exs::Vector{HaloExchange})
+    send_exs = Vector{HaloExchange}()
+    recv_exs = Vector{HaloExchange}()
+    for ex in exs
+        if mpi_chunk_id() == ex.src_chunk_id
+            push!(send_exs, ex)
         end
-        if mpi_chunk_id() == hex.dest_chunk_id
-            push!(recv_hexs, hex)
+        if mpi_chunk_id() == ex.dest_chunk_id
+            push!(recv_exs, ex)
         end
     end
-    return send_hexs, recv_hexs
+    return send_exs, recv_exs
 end
 
-function init_reqs(hexs::Vector{HaloExchangeBuf{B}}) where {B}
-    n_reqs = 0
-    for hex in hexs
-        if mpi_chunk_id() == hex.src_chunk_id
-            n_reqs += hex.n_fields
-        end
-    end
-    return Vector{MPI.Request}(undef, n_reqs)
+function init_reqs(exs::Vector{HaloExchange}, n_halo_fields::Int)
+    n_reqs = length(exs)
+    return [Vector{MPI.Request}(undef, n_reqs) for _ in 1:n_halo_fields]
+end
+
+@inline function get_req_id(ex_id::Int, n_halo_fields::Int, field_id::Int)
+    return ex_id * n_halo_fields + field_id - n_halo_fields
+end
+
+function get_htl_reqests(dh::MPIDataHandler, field::Symbol)
+    field_id = dh.field_to_buf[field]
+    return dh.htl_reqs[field_id]
+end
+
+function get_lth_reqests(dh::MPIDataHandler, field::Symbol)
+    field_id = dh.field_to_buf[field]
+    return dh.lth_reqs[field_id]
 end
 
 function calc_stable_timestep(dh::MPIDataHandler, safety_factor::Float64)
@@ -221,68 +204,88 @@ function calc_stable_timestep(dh::MPIDataHandler, safety_factor::Float64)
 end
 
 function exchange_loc_to_halo!(dh::MPIDataHandler)
-    for (hex_id, hex) in enumerate(dh.lth_exs_send)
-        send_lth!(dh, hex, hex_id)
-    end
-    for hex in dh.lth_exs_recv
-        recv_lth!(dh, hex)
-    end
-    MPI.Waitall(dh.lth_reqs)
+    fields = loc_to_halo_fields(dh.chunk.storage)
+    isempty(fields) && return nothing
+    exchange_loc_to_halo!(dh, fields)
     return nothing
 end
 
-function send_lth!(dh::MPIDataHandler, he::HaloExchangeBuf, hex_id::Int)
-    fields = loc_to_halo_fields(dh.chunk.storage)
-    for i in eachindex(fields, he.bufs)
-        src_field = get_point_data(dh.chunk.storage, fields[i])
-        exchange_to_buf!(he.bufs[i], src_field, he.src_idxs)
-        req = MPI.Isend(he.bufs[i], mpi_comm(); dest=he.dest_chunk_id - 1, tag=he.tags[i])
-        req_id = hex_id * he.n_fields + i - he.n_fields
-        dh.lth_reqs[req_id] = req
+function exchange_loc_to_halo!(dh::MPIDataHandler, fields::NTuple{N,Symbol}) where {N}
+    for field in fields
+        for (ex_id, ex) in enumerate(dh.lth_exs_send)
+            send_lth!(dh, ex, ex_id, field)
+        end
+        for (ex_id, ex) in enumerate(dh.lth_exs_recv)
+            recv_lth!(dh, ex, ex_id, field)
+        end
+        MPI.Waitall(get_lth_reqests(dh, field))
     end
     return nothing
 end
 
-function recv_lth!(dh::MPIDataHandler, he::HaloExchangeBuf)
-    fields = loc_to_halo_fields(dh.chunk.storage)
-    for i in eachindex(fields, he.bufs)
-        MPI.Recv!(he.bufs[i], mpi_comm(); source=he.src_chunk_id - 1, tag=he.tags[i])
-        dest_field = get_point_data(dh.chunk.storage, fields[i])
-        exchange_from_buf!(dest_field, he.bufs[i], he.dest_idxs)
-    end
+function send_lth!(dh::MPIDataHandler, ex::HaloExchange, ex_id::Int, field::Symbol)
+    src_field = get_point_data(dh.chunk.storage, field)
+    field_id = dh.field_to_buf[field]
+    buf = get_buf(dh.lth_send_bufs[ex_id], field_id)
+    exchange_to_buf!(buf, src_field, ex.src_idxs)
+    tag = ex.tag + field_id
+    dest = ex.dest_chunk_id - 1
+    req = MPI.Isend(buf, mpi_comm(); dest=dest, tag=tag)
+    dh.lth_reqs[field_id][ex_id] = req
+    return nothing
+end
+
+function recv_lth!(dh::MPIDataHandler, ex::HaloExchange, ex_id::Int, field::Symbol)
+    field_id = dh.field_to_buf[field]
+    buf = get_buf(dh.lth_recv_bufs[ex_id], field_id)
+    tag = ex.tag + field_id
+    source = ex.src_chunk_id - 1
+    MPI.Recv!(buf, mpi_comm(); source=source, tag=tag)
+    dest_field = get_point_data(dh.chunk.storage, field)
+    exchange_from_buf!(dest_field, buf, ex.dest_idxs)
     return nothing
 end
 
 function exchange_halo_to_loc!(dh::MPIDataHandler)
-    for (hex_id, hex) in enumerate(dh.htl_exs_send)
-        send_htl!(dh, hex, hex_id)
-    end
-    for hex in dh.htl_exs_recv
-        recv_htl!(dh, hex)
-    end
-    MPI.Waitall(dh.htl_reqs)
+    fields = halo_to_loc_fields(dh.chunk.storage)
+    isempty(fields) && return nothing
+    exchange_halo_to_loc!(dh, fields)
     return nothing
 end
 
-function send_htl!(dh::MPIDataHandler, he::HaloExchangeBuf, hex_id::Int)
-    fields = halo_to_loc_fields(dh.chunk.storage)
-    for i in eachindex(fields, he.bufs)
-        src_field = get_point_data(dh.chunk.storage, fields[i])
-        exchange_to_buf!(he.bufs[i], src_field, he.src_idxs)
-        req = MPI.Isend(he.bufs[i], mpi_comm(); dest=he.dest_chunk_id - 1, tag=he.tags[i])
-        req_id = hex_id * he.n_fields + i - he.n_fields
-        dh.htl_reqs[req_id] = req
+function exchange_halo_to_loc!(dh::MPIDataHandler, fields::NTuple{N,Symbol}) where {N}
+    for field in fields
+        for (ex_id, ex) in enumerate(dh.htl_exs_send)
+            send_htl!(dh, ex, ex_id, field)
+        end
+        for (ex_id, ex) in enumerate(dh.htl_exs_recv)
+            recv_htl!(dh, ex, ex_id, field)
+        end
+        MPI.Waitall(get_htl_reqests(dh, field))
     end
     return nothing
 end
 
-function recv_htl!(dh::MPIDataHandler, he::HaloExchangeBuf)
-    fields = halo_to_loc_fields(dh.chunk.storage)
-    for i in eachindex(fields, he.bufs)
-        MPI.Recv!(he.bufs[i], mpi_comm(); source=he.src_chunk_id - 1, tag=he.tags[i])
-        dest_field = get_point_data(dh.chunk.storage, fields[i])
-        exchange_from_buf_add!(dest_field, he.bufs[i], he.dest_idxs)
-    end
+function send_htl!(dh::MPIDataHandler, ex::HaloExchange, ex_id::Int, field::Symbol)
+    src_field = get_point_data(dh.chunk.storage, field)
+    field_id = dh.field_to_buf[field]
+    buf = get_buf(dh.htl_send_bufs[ex_id], field_id)
+    exchange_to_buf!(buf, src_field, ex.src_idxs)
+    tag = ex.tag + field_id
+    dest = ex.dest_chunk_id - 1
+    req = MPI.Isend(buf, mpi_comm(); dest=dest, tag=tag)
+    dh.htl_reqs[field_id][ex_id] = req
+    return nothing
+end
+
+function recv_htl!(dh::MPIDataHandler, ex::HaloExchange, ex_id::Int, field::Symbol)
+    field_id = dh.field_to_buf[field]
+    buf = get_buf(dh.htl_recv_bufs[ex_id], field_id)
+    tag = ex.tag + field_id
+    source = ex.src_chunk_id - 1
+    MPI.Recv!(buf, mpi_comm(); source=source, tag=tag)
+    dest_field = get_point_data(dh.chunk.storage, field)
+    exchange_from_buf_add!(dest_field, buf, ex.dest_idxs)
     return nothing
 end
 

--- a/src/core/mpi_data_handler.jl
+++ b/src/core/mpi_data_handler.jl
@@ -22,12 +22,12 @@ end
 
 struct MPIDataHandler{C<:AbstractBodyChunk,RB,WB} <: AbstractMPIDataHandler
     chunk::C
-    read_hexs_send::Vector{HaloExchangeBuf{RB}}
-    read_hexs_recv::Vector{HaloExchangeBuf{RB}}
-    write_hexs_send::Vector{HaloExchangeBuf{WB}}
-    write_hexs_recv::Vector{HaloExchangeBuf{WB}}
-    read_reqs::Vector{MPI.Request}
-    write_reqs::Vector{MPI.Request}
+    lth_exs_send::Vector{HaloExchangeBuf{RB}}
+    lth_exs_recv::Vector{HaloExchangeBuf{RB}}
+    htl_exs_send::Vector{HaloExchangeBuf{WB}}
+    htl_exs_recv::Vector{HaloExchangeBuf{WB}}
+    lth_reqs::Vector{MPI.Request}
+    htl_reqs::Vector{MPI.Request}
 end
 
 function MPIDataHandler(body::AbstractBody, time_solver::AbstractTimeSolver,
@@ -42,13 +42,13 @@ function MPIDataHandler(body::AbstractBody, time_solver::AbstractTimeSolver,
     chunk = chop_body_mpi(body, time_solver, point_decomp, v)
     @timeit_debug TO "find halo exchanges" begin
         halo_infos = get_halo_infos(chunk, point_decomp, body.n_points)
-        read_hexs, write_hexs = find_halo_exchange_bufs(chunk, halo_infos)
-        read_hexs_send, read_hexs_recv = filter_send_recv(read_hexs)
-        write_hexs_send, write_hexs_recv = filter_send_recv(write_hexs)
-        read_reqs, write_reqs = init_reqs(read_hexs_send), init_reqs(write_hexs_send)
+        lth_exs, htl_exs = find_halo_exchange_bufs(chunk, halo_infos)
+        lth_exs_send, lth_exs_recv = filter_send_recv(lth_exs)
+        htl_exs_send, htl_exs_recv = filter_send_recv(htl_exs)
+        lth_reqs, htl_reqs = init_reqs(lth_exs_send), init_reqs(htl_exs_send)
     end
-    return MPIDataHandler(chunk, read_hexs_send, read_hexs_recv, write_hexs_send,
-                          write_hexs_recv, read_reqs, write_reqs)
+    return MPIDataHandler(chunk, lth_exs_send, lth_exs_recv, htl_exs_send,
+                          htl_exs_recv, lth_reqs, htl_reqs)
 end
 
 function MPIDataHandler(multibody::AbstractMultibodySetup,
@@ -110,38 +110,38 @@ function get_all_point_ids(chunk::AbstractBodyChunk, n_points::Int)
 end
 
 function find_halo_exchange_bufs(chunk::AbstractBodyChunk, halo_infos::MPIHaloInfo)
-    has_read = has_loc_to_halo_exs(chunk)
-    has_write = has_halo_to_loc_exs(chunk)
-    read_hexs, write_hexs = _find_halo_exchange_bufs(chunk, halo_infos, has_read, has_write)
-    return read_hexs, write_hexs
+    has_lth = has_lth_exs(chunk)
+    has_htl = has_htl_exs(chunk)
+    lth_exs, htl_exs = _find_halo_exchange_bufs(chunk, halo_infos, has_lth, has_htl)
+    return lth_exs, htl_exs
 end
 
-function has_loc_to_halo_exs(chunk::AbstractBodyChunk)
+function has_lth_exs(chunk::AbstractBodyChunk)
     hrfs = loc_to_halo_fields(chunk.storage)
     isempty(hrfs) && return false
     return true
 end
 
-function has_halo_to_loc_exs(chunk::AbstractBodyChunk)
+function has_htl_exs(chunk::AbstractBodyChunk)
     hwfs = halo_to_loc_fields(chunk.storage)
     isempty(hwfs) && return false
     return true
 end
 
 function _find_halo_exchange_bufs(chunk::AbstractBodyChunk, halo_info::MPIHaloInfo,
-                                  hasread::Bool, haswrite::Bool)
+                                  has_lth::Bool, has_htl::Bool)
     RB = get_loc_to_halo_buftype(chunk.storage)
     WB = get_halo_to_loc_buftype(chunk.storage)
-    read_hexs = Vector{HaloExchangeBuf{RB}}()
-    write_hexs = Vector{HaloExchangeBuf{WB}}()
+    lth_exs = Vector{HaloExchangeBuf{RB}}()
+    htl_exs = Vector{HaloExchangeBuf{WB}}()
     ccid = mpi_chunk_id()
     for (cid, hidxs_by_src) in halo_info.hidxs_by_src
         for (hcid, idxs) in hidxs_by_src
-            _find_hexs!(read_hexs, write_hexs, chunk, halo_info, ccid, cid, hcid, idxs,
-                        hasread, haswrite)
+            _find_hexs!(lth_exs, htl_exs, chunk, halo_info, ccid, cid, hcid, idxs,
+                        has_lth, has_htl)
         end
     end
-    return read_hexs, write_hexs
+    return lth_exs, htl_exs
 end
 
 @inline function get_loc_to_halo_buftype(s::AbstractStorage)
@@ -154,18 +154,18 @@ end
 
 function _find_hexs!(rhexs::Vector, whexs::Vector, chunk::AbstractBodyChunk,
                      hi::MPIHaloInfo, ccid::Int, cid::Int, hcid::Int, idxs::Vector{Int},
-                     hasread::Bool, haswrite::Bool)
+                     has_lth::Bool, has_htl::Bool)
     (ccid == cid || ccid == hcid) || return nothing
     hidxs = hi.point_ids[cid][idxs]
     localize!(hidxs, hi.localizers[hcid])
-    if hasread
+    if has_lth
         bufs = get_loc_to_halo_bufs(chunk.storage, length(idxs))
         tags = get_tags(bufs, cid * mpi_nranks())
         n_fields = length(bufs)
         hex = HaloExchangeBuf(n_fields, hcid, cid, hidxs, idxs, bufs, tags)
         push!(rhexs, hex)
     end
-    if haswrite
+    if has_htl
         bufs = get_loc_to_halo_bufs(chunk.storage, length(idxs))
         tags = get_tags(bufs, cid * mpi_nranks())
         n_fields = length(bufs)
@@ -221,29 +221,29 @@ function calc_stable_timestep(dh::MPIDataHandler, safety_factor::Float64)
 end
 
 function exchange_loc_to_halo!(dh::MPIDataHandler)
-    for (hex_id, hex) in enumerate(dh.read_hexs_send)
-        send_read_he!(dh, hex, hex_id)
+    for (hex_id, hex) in enumerate(dh.lth_exs_send)
+        send_lth!(dh, hex, hex_id)
     end
-    for hex in dh.read_hexs_recv
-        recv_read_he!(dh, hex)
+    for hex in dh.lth_exs_recv
+        recv_lth!(dh, hex)
     end
-    MPI.Waitall(dh.read_reqs)
+    MPI.Waitall(dh.lth_reqs)
     return nothing
 end
 
-function send_read_he!(dh::MPIDataHandler, he::HaloExchangeBuf, hex_id::Int)
+function send_lth!(dh::MPIDataHandler, he::HaloExchangeBuf, hex_id::Int)
     fields = loc_to_halo_fields(dh.chunk.storage)
     for i in eachindex(fields, he.bufs)
         src_field = get_point_data(dh.chunk.storage, fields[i])
         exchange_to_buf!(he.bufs[i], src_field, he.src_idxs)
         req = MPI.Isend(he.bufs[i], mpi_comm(); dest=he.dest_chunk_id - 1, tag=he.tags[i])
         req_id = hex_id * he.n_fields + i - he.n_fields
-        dh.read_reqs[req_id] = req
+        dh.lth_reqs[req_id] = req
     end
     return nothing
 end
 
-function recv_read_he!(dh::MPIDataHandler, he::HaloExchangeBuf)
+function recv_lth!(dh::MPIDataHandler, he::HaloExchangeBuf)
     fields = loc_to_halo_fields(dh.chunk.storage)
     for i in eachindex(fields, he.bufs)
         MPI.Recv!(he.bufs[i], mpi_comm(); source=he.src_chunk_id - 1, tag=he.tags[i])
@@ -254,29 +254,29 @@ function recv_read_he!(dh::MPIDataHandler, he::HaloExchangeBuf)
 end
 
 function exchange_halo_to_loc!(dh::MPIDataHandler)
-    for (hex_id, hex) in enumerate(dh.write_hexs_send)
-        send_write_he!(dh, hex, hex_id)
+    for (hex_id, hex) in enumerate(dh.htl_exs_send)
+        send_htl!(dh, hex, hex_id)
     end
-    for hex in dh.write_hexs_recv
-        recv_write_he!(dh, hex)
+    for hex in dh.htl_exs_recv
+        recv_htl!(dh, hex)
     end
-    MPI.Waitall(dh.write_reqs)
+    MPI.Waitall(dh.htl_reqs)
     return nothing
 end
 
-function send_write_he!(dh::MPIDataHandler, he::HaloExchangeBuf, hex_id::Int)
+function send_htl!(dh::MPIDataHandler, he::HaloExchangeBuf, hex_id::Int)
     fields = halo_to_loc_fields(dh.chunk.storage)
     for i in eachindex(fields, he.bufs)
         src_field = get_point_data(dh.chunk.storage, fields[i])
         exchange_to_buf!(he.bufs[i], src_field, he.src_idxs)
         req = MPI.Isend(he.bufs[i], mpi_comm(); dest=he.dest_chunk_id - 1, tag=he.tags[i])
         req_id = hex_id * he.n_fields + i - he.n_fields
-        dh.write_reqs[req_id] = req
+        dh.htl_reqs[req_id] = req
     end
     return nothing
 end
 
-function recv_write_he!(dh::MPIDataHandler, he::HaloExchangeBuf)
+function recv_htl!(dh::MPIDataHandler, he::HaloExchangeBuf)
     fields = halo_to_loc_fields(dh.chunk.storage)
     for i in eachindex(fields, he.bufs)
         MPI.Recv!(he.bufs[i], mpi_comm(); source=he.src_chunk_id - 1, tag=he.tags[i])

--- a/src/core/storages.jl
+++ b/src/core/storages.jl
@@ -37,11 +37,8 @@ macro loc_to_halo_fields(storage, fields...)
     macrocheck_input_storage(storage)
     macrocheck_input_fields(fields...)
     local _checks = quote
-        if !($(esc(storage)) <: Peridynamics.AbstractStorage)
-            msg = Base.string($(esc(storage)), " is not a valid storage type!\n")
-            throw(ArgumentError(msg))
-        end
-        Peridynamics.typecheck_storage_has_fields($(esc(storage)), $(Expr(:tuple, fields...)))
+        Peridynamics.typecheck_is_storage($(esc(storage)))
+        Peridynamics.typecheck_storage_fields($(esc(storage)), $(Expr(:tuple, fields...)))
     end
     local _loc_to_halo_fields = quote
         function Peridynamics.loc_to_halo_fields(::$(esc(storage)))
@@ -63,16 +60,31 @@ macro halo_to_loc_fields(storage, fields...)
     macrocheck_input_storage(storage)
     macrocheck_input_fields(fields...)
     local _checks = quote
-        if !($(esc(storage)) <: Peridynamics.AbstractStorage)
-            msg = Base.string($(esc(storage)), " is not a valid storage type!\n")
-            throw(ArgumentError(msg))
-        end
-        Peridynamics.typecheck_storage_has_fields($(esc(storage)), $(Expr(:tuple, fields...)))
+        Peridynamics.typecheck_is_storage($(esc(storage)))
+        Peridynamics.typecheck_storage_fields($(esc(storage)), $(Expr(:tuple, fields...)))
     end
     local _loc_to_halo_fields = quote
         function Peridynamics.halo_to_loc_fields(::$(esc(storage)))
             return $(Expr(:tuple, fields...))
         end
+    end
+    local _is_halo_fields = [
+        quote
+            function Peridynamics.is_halo_field(::$(esc(storage)), ::Val{$(esc(_field))})
+                return true
+            end
+        end
+        for _field in fields
+    ]
+    return Expr(:block, _checks, _loc_to_halo_fields, _is_halo_fields...)
+end
+
+macro halo_fields(storage, fields...)
+    macrocheck_input_storage(storage)
+    macrocheck_input_fields(fields...)
+    local _checks = quote
+        Peridynamics.typecheck_is_storage($(esc(storage)))
+        Peridynamics.typecheck_storage_fields($(esc(storage)), $(Expr(:tuple, fields...)))
     end
     local _is_halo_fields = [
         quote
@@ -109,18 +121,23 @@ function macrocheck_input_fields(fields...)
     return nothing
 end
 
-function typecheck_storage(::Type{Storage}, ::Type{TimeSolver}) where {Storage,TimeSolver}
+function typecheck_is_storage(::Type{Storage}) where {Storage}
     if !(Storage <: AbstractStorage)
         msg = "$Storage is not a valid storage type!\n"
         throw(ArgumentError(msg))
     end
+    return nothing
+end
+
+function typecheck_storage(::Type{Storage}, ::Type{TimeSolver}) where {Storage,TimeSolver}
+    typecheck_is_storage(Storage)
     # TODO: add the material type! Then users can add requirements for own materials
     req_storage_fields_timesolver(Storage, TimeSolver)
     req_storage_fields_fracture(Storage)
     return nothing
 end
 
-function typecheck_storage_has_fields(::Type{S}, fields::NTuple{N,Symbol}) where {S,N}
+function typecheck_storage_fields(::Type{S}, fields::NTuple{N,Symbol}) where {S,N}
     storage_fields = fieldnames(S)
     for field in fields
         if !in(field, storage_fields)
@@ -144,6 +161,7 @@ point_data_field(s::AbstractStorage, ::Val{:b_int}) = getfield(s, :b_int)
 point_data_field(s::AbstractStorage, ::Val{:b_ext}) = getfield(s, :b_ext)
 point_data_field(s::AbstractStorage, ::Val{:damage}) = getfield(s, :damage)
 point_data_field(s::AbstractStorage, ::Val{:n_active_bonds}) = getfield(s, :n_active_bonds)
+# point_data_field(s::AbstractStorage, ::Val{Field}) where {Field} = getfield(s, Field)
 
 function point_data_field(::AbstractStorage, ::Val{field}) where {field}
     return throw(ArgumentError("field $field is not a valid point data field!\n"))
@@ -162,6 +180,24 @@ end
 
 function get_halo_to_loc_fields(s::AbstractStorage)
     return Tuple(get_point_data(s, field) for field in halo_to_loc_fields(s))
+end
+
+function get_halo_fields(s::S) where {S<:AbstractStorage}
+    return Tuple(get_point_data(s, f) for f in fieldnames(S) if is_halo_field(s, Val(f)))
+end
+
+function get_halo_fieldnames(s::S) where {S<:AbstractStorage}
+    return Tuple(f for f in fieldnames(S) if is_halo_field(s, Val(f)))
+end
+
+function get_n_halo_fields(s::S) where {S<:AbstractStorage}
+    n_halo_fields = 0
+    for f in fieldnames(S)
+        if is_halo_field(s, Val(f))
+            n_halo_fields += 1
+        end
+    end
+    return n_halo_fields
 end
 
 function get_loc_point_data(s::AbstractStorage, ch::AbstractChunkHandler, field::Symbol)

--- a/src/core/storages.jl
+++ b/src/core/storages.jl
@@ -29,11 +29,11 @@ macro storage(material, timesolver, storage)
     return Expr(:block, _checks, _storage_type, _init_storage)
 end
 
-halo_read_fields(::AbstractStorage) = ()
-halo_write_fields(::AbstractStorage) = ()
+loc_to_halo_fields(::AbstractStorage) = ()
+halo_to_loc_fields(::AbstractStorage) = ()
 is_halo_field(::AbstractStorage, ::Val{F}) where {F} = false
 
-macro halo_read_fields(storage, fields...)
+macro loc_to_halo_fields(storage, fields...)
     macrocheck_input_storage(storage)
     macrocheck_input_fields(fields...)
     local _checks = quote
@@ -43,8 +43,8 @@ macro halo_read_fields(storage, fields...)
         end
         Peridynamics.typecheck_storage_has_fields($(esc(storage)), $(Expr(:tuple, fields...)))
     end
-    local _halo_read_fields = quote
-        function Peridynamics.halo_read_fields(::$(esc(storage)))
+    local _loc_to_halo_fields = quote
+        function Peridynamics.loc_to_halo_fields(::$(esc(storage)))
             return $(Expr(:tuple, fields...))
         end
     end
@@ -56,10 +56,10 @@ macro halo_read_fields(storage, fields...)
         end
         for _field in fields
     ]
-    return Expr(:block, _checks, _halo_read_fields, _is_halo_fields...)
+    return Expr(:block, _checks, _loc_to_halo_fields, _is_halo_fields...)
 end
 
-macro halo_write_fields(storage, fields...)
+macro halo_to_loc_fields(storage, fields...)
     macrocheck_input_storage(storage)
     macrocheck_input_fields(fields...)
     local _checks = quote
@@ -69,8 +69,8 @@ macro halo_write_fields(storage, fields...)
         end
         Peridynamics.typecheck_storage_has_fields($(esc(storage)), $(Expr(:tuple, fields...)))
     end
-    local _halo_read_fields = quote
-        function Peridynamics.halo_write_fields(::$(esc(storage)))
+    local _loc_to_halo_fields = quote
+        function Peridynamics.halo_to_loc_fields(::$(esc(storage)))
             return $(Expr(:tuple, fields...))
         end
     end
@@ -82,7 +82,7 @@ macro halo_write_fields(storage, fields...)
         end
         for _field in fields
     ]
-    return Expr(:block, _checks, _halo_read_fields, _is_halo_fields...)
+    return Expr(:block, _checks, _loc_to_halo_fields, _is_halo_fields...)
 end
 
 function macrocheck_input_storage(storage)
@@ -156,12 +156,12 @@ function point_data_fields(::Type{S}) where {S<:AbstractStorage}
     return fields
 end
 
-function get_halo_read_fields(s::AbstractStorage)
-    return Tuple(get_point_data(s, field) for field in halo_read_fields(s))
+function get_loc_to_halo_fields(s::AbstractStorage)
+    return Tuple(get_point_data(s, field) for field in loc_to_halo_fields(s))
 end
 
-function get_halo_write_fields(s::AbstractStorage)
-    return Tuple(get_point_data(s, field) for field in halo_write_fields(s))
+function get_halo_to_loc_fields(s::AbstractStorage)
+    return Tuple(get_point_data(s, field) for field in halo_to_loc_fields(s))
 end
 
 function get_loc_point_data(s::AbstractStorage, ch::AbstractChunkHandler, field::Symbol)

--- a/src/core/threads_data_handler.jl
+++ b/src/core/threads_data_handler.jl
@@ -8,8 +8,8 @@ end
 struct ThreadsDataHandler{C<:AbstractBodyChunk} <: AbstractThreadsDataHandler
     n_chunks::Int
     chunks::Vector{C}
-    loc_to_halo_exs::Vector{Vector{HaloExchange}}
-    halo_to_loc_exs::Vector{Vector{HaloExchange}}
+    lth_exs::Vector{Vector{HaloExchange}}
+    htl_exs::Vector{Vector{HaloExchange}}
 end
 
 function ThreadsDataHandler(body::AbstractBody, time_solver::AbstractTimeSolver,
@@ -23,8 +23,8 @@ function ThreadsDataHandler(body::AbstractBody, time_solver::AbstractTimeSolver,
                             point_decomp::PointDecomposition, v::Val{N}) where {N}
     chunks = chop_body_threads(body, time_solver, point_decomp, v)
     n_chunks = length(chunks)
-    loc_to_halo_exs, halo_to_loc_exs = find_halo_exchanges(chunks)
-    return ThreadsDataHandler(n_chunks, chunks, loc_to_halo_exs, halo_to_loc_exs)
+    lth_exs, htl_exs = find_halo_exchanges(chunks)
+    return ThreadsDataHandler(n_chunks, chunks, lth_exs, htl_exs)
 end
 
 function ThreadsDataHandler(multibody::AbstractMultibodySetup,
@@ -70,25 +70,25 @@ function _chop_body_threads(body::Body{M,P}, ts::T, pd::PointDecomposition, ::Ty
 end
 
 function find_halo_exchanges(chunks::Vector{B}) where {B<:AbstractBodyChunk}
-    has_lth = has_loc_to_halo_exs(chunks)
-    has_htl = has_halo_to_loc_exs(chunks)
-    loc_to_halo_exs = Vector{Vector{HaloExchange}}(undef, length(chunks))
-    halo_to_loc_exs = Vector{Vector{HaloExchange}}(undef, length(chunks))
+    has_lth = has_lth_exs(chunks)
+    has_htl = has_htl_exs(chunks)
+    lth_exs = Vector{Vector{HaloExchange}}(undef, length(chunks))
+    htl_exs = Vector{Vector{HaloExchange}}(undef, length(chunks))
     @threads :static for chunk_id in eachindex(chunks)
-        lth_exs, htl_exs = find_exs(chunks, chunk_id, has_lth, has_htl)
-        loc_to_halo_exs[chunk_id] = lth_exs
-        halo_to_loc_exs[chunk_id] = htl_exs
+        _lth_exs, _htl_exs = find_exs(chunks, chunk_id, has_lth, has_htl)
+        lth_exs[chunk_id] = _lth_exs
+        htl_exs[chunk_id] = _htl_exs
     end
-    reorder_htl_exs!(halo_to_loc_exs)
-    return loc_to_halo_exs, halo_to_loc_exs
+    reorder_htl_exs!(htl_exs)
+    return lth_exs, htl_exs
 end
 
-function has_loc_to_halo_exs(chunks::Vector{B}) where {B<:AbstractBodyChunk}
-    return has_loc_to_halo_exs(first(chunks))
+function has_lth_exs(chunks::Vector{B}) where {B<:AbstractBodyChunk}
+    return has_lth_exs(first(chunks))
 end
 
-function has_halo_to_loc_exs(chunks::Vector{B}) where {B<:AbstractBodyChunk}
-    return has_halo_to_loc_exs(first(chunks))
+function has_htl_exs(chunks::Vector{B}) where {B<:AbstractBodyChunk}
+    return has_htl_exs(first(chunks))
 end
 
 function find_exs(chunks::Vector{B}, chunk_id::Int, has_lth::Bool,
@@ -106,10 +106,10 @@ function find_exs(chunks::Vector{B}, chunk_id::Int, has_lth::Bool,
     return lth_exs, htl_exs
 end
 
-function reorder_htl_exs!(halo_to_loc_exs::Vector{Vector{HaloExchange}})
-    all_write_exs = reduce(vcat, halo_to_loc_exs)
-    @threads :static for chunk_id in eachindex(halo_to_loc_exs)
-        halo_to_loc_exs[chunk_id] = filter(x -> x.dest_chunk_id == chunk_id, all_write_exs)
+function reorder_htl_exs!(htl_exs::Vector{Vector{HaloExchange}})
+    all_htl_exs = reduce(vcat, htl_exs)
+    @threads :static for chunk_id in eachindex(htl_exs)
+        htl_exs[chunk_id] = filter(x -> x.dest_chunk_id == chunk_id, all_htl_exs)
     end
     return nothing
 end
@@ -125,7 +125,7 @@ end
 get_cells(n::Int) = [MeshCell(VTKCellTypes.VTK_VERTEX, (i,)) for i in 1:n]
 
 function exchange_loc_to_halo!(dh::ThreadsDataHandler, chunk_id::Int)
-    for he in dh.loc_to_halo_exs[chunk_id]
+    for he in dh.lth_exs[chunk_id]
         dest_storage = dh.chunks[he.dest_chunk_id].storage
         src_storage = dh.chunks[he.src_chunk_id].storage
         _exchange_loc_to_halo!(dest_storage, src_storage, he)
@@ -143,7 +143,7 @@ function _exchange_loc_to_halo!(dest_storage::S, src_storage::S, he::HaloExchang
 end
 
 function exchange_halo_to_loc!(dh::ThreadsDataHandler, chunk_id::Int)
-    for he in dh.halo_to_loc_exs[chunk_id]
+    for he in dh.htl_exs[chunk_id]
         dest_storage = dh.chunks[he.dest_chunk_id].storage
         src_storage = dh.chunks[he.src_chunk_id].storage
         _exchange_halo_to_loc!(dest_storage, src_storage, he)

--- a/src/core/threads_data_handler.jl
+++ b/src/core/threads_data_handler.jl
@@ -134,7 +134,7 @@ function exchange_loc_to_halo!(dh::ThreadsDataHandler, chunk_id::Int)
 end
 
 function _exchange_loc_to_halo!(dest_storage::S, src_storage::S, he::HaloExchange) where {S}
-    for field in halo_read_fields(dest_storage)
+    for field in loc_to_halo_fields(dest_storage)
         dest_field = get_point_data(dest_storage, field)
         src_field = get_point_data(src_storage, field)
         exchange!(dest_field, src_field, he.dest_idxs, he.src_idxs)
@@ -153,7 +153,7 @@ end
 
 function _exchange_halo_to_loc!(dest_storage::S, src_storage::S,
                                  he::HaloExchange) where {S}
-    for field in halo_write_fields(dest_storage)
+    for field in halo_to_loc_fields(dest_storage)
         dest_field = get_point_data(dest_storage, field)
         src_field = get_point_data(src_storage, field)
         exchange_add!(dest_field, src_field, he.dest_idxs, he.src_idxs)

--- a/src/physics/bond_based.jl
+++ b/src/physics/bond_based.jl
@@ -93,7 +93,7 @@ end
 
 @storage BBMaterial VelocityVerlet BBVerletStorage
 
-@halo_read_fields BBVerletStorage :position
+@loc_to_halo_fields BBVerletStorage :position
 
 function force_density_point!(s::BBVerletStorage, bd::BondSystem, ::BBMaterial,
                               param::BBPointParameters, i::Int)

--- a/src/physics/correspondence.jl
+++ b/src/physics/correspondence.jl
@@ -90,8 +90,8 @@ end
 
 @storage NOSBMaterial VelocityVerlet NOSBVerletStorage
 
-@halo_read_fields NOSBVerletStorage :position
-@halo_write_fields NOSBVerletStorage :b_int
+@loc_to_halo_fields NOSBVerletStorage :position
+@halo_to_loc_fields NOSBVerletStorage :b_int
 
 function force_density_point!(s::NOSBVerletStorage, bd::BondSystem, mat::NOSBMaterial,
                               param::NOSBPointParameters, i::Int)

--- a/src/physics/ordinary_state_based.jl
+++ b/src/physics/ordinary_state_based.jl
@@ -85,8 +85,8 @@ end
 
 @storage OSBMaterial VelocityVerlet OSBVerletStorage
 
-@halo_read_fields OSBVerletStorage :position
-@halo_write_fields OSBVerletStorage :b_int
+@loc_to_halo_fields OSBVerletStorage :position
+@halo_to_loc_fields OSBVerletStorage :b_int
 
 function force_density_point!(s::OSBVerletStorage, bd::BondSystem, ::OSBMaterial,
                               param::OSBPointParameters, i::Int)

--- a/src/time_solvers/velocity_verlet.jl
+++ b/src/time_solvers/velocity_verlet.jl
@@ -212,11 +212,11 @@ function solve_timestep!(dh::AbstractThreadsDataHandler, options::AbstractOption
         update_disp_and_pos!(chunk, Δt)
     end
     @threads :static for chunk_id in eachindex(dh.chunks)
-        exchange_read_fields!(dh, chunk_id)
+        exchange_loc_to_halo!(dh, chunk_id)
         calc_force_density!(dh.chunks[chunk_id])
     end
     @threads :static for chunk_id in eachindex(dh.chunks)
-        exchange_write_fields!(dh, chunk_id)
+        exchange_halo_to_loc!(dh, chunk_id)
         chunk = dh.chunks[chunk_id]
         calc_damage!(chunk)
         update_acc_and_vel!(chunk, Δt½)
@@ -247,9 +247,9 @@ function solve_timestep!(dh::AbstractMPIDataHandler, options::AbstractOptions, �
     @timeit_debug TO "update_vel_half!" update_vel_half!(chunk, Δt½)
     @timeit_debug TO "apply_bcs!" apply_bcs!(chunk, t)
     @timeit_debug TO "update_disp_and_pos!" update_disp_and_pos!(chunk, Δt)
-    @timeit_debug TO "exchange_read_fields!" exchange_read_fields!(dh)
+    @timeit_debug TO "exchange_loc_to_halo!" exchange_loc_to_halo!(dh)
     @timeit_debug TO "calc_force_density!" calc_force_density!(chunk)
-    @timeit_debug TO "exchange_write_fields!" exchange_write_fields!(dh)
+    @timeit_debug TO "exchange_halo_to_loc!" exchange_halo_to_loc!(dh)
     @timeit_debug TO "calc_damage!" calc_damage!(chunk)
     @timeit_debug TO "update_acc_and_vel!" update_acc_and_vel!(chunk, Δt½)
     @timeit_debug TO "export_results" export_results(dh, options, n, t)

--- a/test/core/test_halo_exchange.jl
+++ b/test/core/test_halo_exchange.jl
@@ -18,6 +18,7 @@
     body_chunks = Peridynamics.chop_body_threads(body, ts, point_decomp, Val{1}())
 
     lth_exs, htl_exs = Peridynamics.find_halo_exchanges(body_chunks)
+
     @test lth_exs[1][1].src_chunk_id == 2
     @test lth_exs[1][1].dest_chunk_id == 1
     @test lth_exs[1][1].src_idxs == [1, 2]
@@ -26,8 +27,15 @@
     @test lth_exs[2][1].dest_chunk_id == 2
     @test lth_exs[2][1].src_idxs == [1, 2]
     @test lth_exs[2][1].dest_idxs == [3, 4]
-    @test isempty(htl_exs[1])
-    @test isempty(htl_exs[2])
+
+    @test htl_exs[1][1].src_chunk_id == 2
+    @test htl_exs[1][1].dest_chunk_id == 1
+    @test htl_exs[1][1].src_idxs == [3, 4]
+    @test htl_exs[1][1].dest_idxs == [1, 2]
+    @test htl_exs[2][1].src_chunk_id == 1
+    @test htl_exs[2][1].dest_chunk_id == 2
+    @test htl_exs[2][1].src_idxs == [3, 4]
+    @test htl_exs[2][1].dest_idxs == [1, 2]
 
     point_decomp = Peridynamics.PointDecomposition(body, 4)
     body_chunks = Peridynamics.chop_body_threads(body, ts, point_decomp, Val{1}())

--- a/test/core/test_halo_exchange.jl
+++ b/test/core/test_halo_exchange.jl
@@ -17,24 +17,24 @@
     point_decomp = Peridynamics.PointDecomposition(body, 2)
     body_chunks = Peridynamics.chop_body_threads(body, ts, point_decomp, Val{1}())
 
-    loc_to_halo_exs, halo_to_loc_exs = Peridynamics.find_halo_exchanges(body_chunks)
-    @test loc_to_halo_exs[1][1].src_chunk_id == 2
-    @test loc_to_halo_exs[1][1].dest_chunk_id == 1
-    @test loc_to_halo_exs[1][1].src_idxs == [1, 2]
-    @test loc_to_halo_exs[1][1].dest_idxs == [3, 4]
-    @test loc_to_halo_exs[2][1].src_chunk_id == 1
-    @test loc_to_halo_exs[2][1].dest_chunk_id == 2
-    @test loc_to_halo_exs[2][1].src_idxs == [1, 2]
-    @test loc_to_halo_exs[2][1].dest_idxs == [3, 4]
-    @test isempty(halo_to_loc_exs[1])
-    @test isempty(halo_to_loc_exs[2])
+    lth_exs, htl_exs = Peridynamics.find_halo_exchanges(body_chunks)
+    @test lth_exs[1][1].src_chunk_id == 2
+    @test lth_exs[1][1].dest_chunk_id == 1
+    @test lth_exs[1][1].src_idxs == [1, 2]
+    @test lth_exs[1][1].dest_idxs == [3, 4]
+    @test lth_exs[2][1].src_chunk_id == 1
+    @test lth_exs[2][1].dest_chunk_id == 2
+    @test lth_exs[2][1].src_idxs == [1, 2]
+    @test lth_exs[2][1].dest_idxs == [3, 4]
+    @test isempty(htl_exs[1])
+    @test isempty(htl_exs[2])
 
     point_decomp = Peridynamics.PointDecomposition(body, 4)
     body_chunks = Peridynamics.chop_body_threads(body, ts, point_decomp, Val{1}())
 
-    loc_to_halo_exs, halo_to_loc_exs = Peridynamics.find_halo_exchanges(body_chunks)
+    lth_exs, htl_exs = Peridynamics.find_halo_exchanges(body_chunks)
 
-    he1 = sort(loc_to_halo_exs[1]; by=x -> x.src_chunk_id)
+    he1 = sort(lth_exs[1]; by=x -> x.src_chunk_id)
     @test he1[1].src_chunk_id == 2
     @test he1[1].dest_chunk_id == 1
     @test he1[1].src_idxs == [1]
@@ -48,7 +48,7 @@
     @test he1[3].src_idxs == [1]
     @test he1[3].dest_idxs == [4]
 
-    he2 = sort(loc_to_halo_exs[2]; by=x -> x.src_chunk_id)
+    he2 = sort(lth_exs[2]; by=x -> x.src_chunk_id)
     @test he2[1].src_chunk_id == 1
     @test he2[1].dest_chunk_id == 2
     @test he2[1].src_idxs == [1]
@@ -62,7 +62,7 @@
     @test he2[3].src_idxs == [1]
     @test he2[3].dest_idxs == [4]
 
-    he3 = sort(loc_to_halo_exs[3]; by=x -> x.src_chunk_id)
+    he3 = sort(lth_exs[3]; by=x -> x.src_chunk_id)
     @test he3[1].src_chunk_id == 1
     @test he3[1].dest_chunk_id == 3
     @test he3[1].src_idxs == [1]
@@ -76,7 +76,7 @@
     @test he3[3].src_idxs == [1]
     @test he3[3].dest_idxs == [4]
 
-    he4 = sort(loc_to_halo_exs[4]; by=x -> x.src_chunk_id)
+    he4 = sort(lth_exs[4]; by=x -> x.src_chunk_id)
     @test he4[1].src_chunk_id == 1
     @test he4[1].dest_chunk_id == 4
     @test he4[1].src_idxs == [1]

--- a/test/core/test_halo_exchange.jl
+++ b/test/core/test_halo_exchange.jl
@@ -91,7 +91,7 @@
     @test he4[3].dest_idxs == [4]
 end
 
-@testitem "exchange_read_fields! BBMaterial" begin
+@testitem "exchange_loc_to_halo! BBMaterial" begin
     position = [0.0 1.0 0.0 0.0
                 0.0 0.0 1.0 0.0
                 0.0 0.0 0.0 1.0]
@@ -136,7 +136,7 @@ end
 
     randpos = rand(3, 4)
     tdh.chunks[2].storage.position .= randpos
-    Peridynamics.exchange_read_fields!(tdh, 1)
+    Peridynamics.exchange_loc_to_halo!(tdh, 1)
 
     @test b1 isa Peridynamics.BodyChunk
     @test b1.storage.position[:,1:2] ≈ [0.0 1.0; 0.0 0.0; 0.0 0.0]

--- a/test/core/test_halo_exchange.jl
+++ b/test/core/test_halo_exchange.jl
@@ -17,24 +17,24 @@
     point_decomp = Peridynamics.PointDecomposition(body, 2)
     body_chunks = Peridynamics.chop_body_threads(body, ts, point_decomp, Val{1}())
 
-    read_halo_exs, write_halo_exs = Peridynamics.find_halo_exchanges(body_chunks)
-    @test read_halo_exs[1][1].src_chunk_id == 2
-    @test read_halo_exs[1][1].dest_chunk_id == 1
-    @test read_halo_exs[1][1].src_idxs == [1, 2]
-    @test read_halo_exs[1][1].dest_idxs == [3, 4]
-    @test read_halo_exs[2][1].src_chunk_id == 1
-    @test read_halo_exs[2][1].dest_chunk_id == 2
-    @test read_halo_exs[2][1].src_idxs == [1, 2]
-    @test read_halo_exs[2][1].dest_idxs == [3, 4]
-    @test isempty(write_halo_exs[1])
-    @test isempty(write_halo_exs[2])
+    loc_to_halo_exs, halo_to_loc_exs = Peridynamics.find_halo_exchanges(body_chunks)
+    @test loc_to_halo_exs[1][1].src_chunk_id == 2
+    @test loc_to_halo_exs[1][1].dest_chunk_id == 1
+    @test loc_to_halo_exs[1][1].src_idxs == [1, 2]
+    @test loc_to_halo_exs[1][1].dest_idxs == [3, 4]
+    @test loc_to_halo_exs[2][1].src_chunk_id == 1
+    @test loc_to_halo_exs[2][1].dest_chunk_id == 2
+    @test loc_to_halo_exs[2][1].src_idxs == [1, 2]
+    @test loc_to_halo_exs[2][1].dest_idxs == [3, 4]
+    @test isempty(halo_to_loc_exs[1])
+    @test isempty(halo_to_loc_exs[2])
 
     point_decomp = Peridynamics.PointDecomposition(body, 4)
     body_chunks = Peridynamics.chop_body_threads(body, ts, point_decomp, Val{1}())
 
-    read_halo_exs, write_halo_exs = Peridynamics.find_halo_exchanges(body_chunks)
+    loc_to_halo_exs, halo_to_loc_exs = Peridynamics.find_halo_exchanges(body_chunks)
 
-    he1 = sort(read_halo_exs[1]; by=x -> x.src_chunk_id)
+    he1 = sort(loc_to_halo_exs[1]; by=x -> x.src_chunk_id)
     @test he1[1].src_chunk_id == 2
     @test he1[1].dest_chunk_id == 1
     @test he1[1].src_idxs == [1]
@@ -48,7 +48,7 @@
     @test he1[3].src_idxs == [1]
     @test he1[3].dest_idxs == [4]
 
-    he2 = sort(read_halo_exs[2]; by=x -> x.src_chunk_id)
+    he2 = sort(loc_to_halo_exs[2]; by=x -> x.src_chunk_id)
     @test he2[1].src_chunk_id == 1
     @test he2[1].dest_chunk_id == 2
     @test he2[1].src_idxs == [1]
@@ -62,7 +62,7 @@
     @test he2[3].src_idxs == [1]
     @test he2[3].dest_idxs == [4]
 
-    he3 = sort(read_halo_exs[3]; by=x -> x.src_chunk_id)
+    he3 = sort(loc_to_halo_exs[3]; by=x -> x.src_chunk_id)
     @test he3[1].src_chunk_id == 1
     @test he3[1].dest_chunk_id == 3
     @test he3[1].src_idxs == [1]
@@ -76,7 +76,7 @@
     @test he3[3].src_idxs == [1]
     @test he3[3].dest_idxs == [4]
 
-    he4 = sort(read_halo_exs[4]; by=x -> x.src_chunk_id)
+    he4 = sort(loc_to_halo_exs[4]; by=x -> x.src_chunk_id)
     @test he4[1].src_chunk_id == 1
     @test he4[1].dest_chunk_id == 4
     @test he4[1].src_idxs == [1]

--- a/test/core/test_threads_data_handler.jl
+++ b/test/core/test_threads_data_handler.jl
@@ -20,8 +20,8 @@
     @test length(tdh.chunks) == 2
     @test length(tdh.lth_exs[1]) == 1
     @test length(tdh.lth_exs[2]) == 1
-    @test isempty(tdh.htl_exs[1])
-    @test isempty(tdh.htl_exs[2])
+    @test length(tdh.htl_exs[1]) == 1
+    @test length(tdh.htl_exs[2]) == 1
 
     #TODO
 end

--- a/test/core/test_threads_data_handler.jl
+++ b/test/core/test_threads_data_handler.jl
@@ -18,10 +18,10 @@
 
     @test tdh.n_chunks == 2
     @test length(tdh.chunks) == 2
-    @test length(tdh.read_halo_exs[1]) == 1
-    @test length(tdh.read_halo_exs[2]) == 1
-    @test isempty(tdh.write_halo_exs[1])
-    @test isempty(tdh.write_halo_exs[2])
+    @test length(tdh.loc_to_halo_exs[1]) == 1
+    @test length(tdh.loc_to_halo_exs[2]) == 1
+    @test isempty(tdh.halo_to_loc_exs[1])
+    @test isempty(tdh.halo_to_loc_exs[2])
 
     #TODO
 end

--- a/test/core/test_threads_data_handler.jl
+++ b/test/core/test_threads_data_handler.jl
@@ -18,10 +18,10 @@
 
     @test tdh.n_chunks == 2
     @test length(tdh.chunks) == 2
-    @test length(tdh.loc_to_halo_exs[1]) == 1
-    @test length(tdh.loc_to_halo_exs[2]) == 1
-    @test isempty(tdh.halo_to_loc_exs[1])
-    @test isempty(tdh.halo_to_loc_exs[2])
+    @test length(tdh.lth_exs[1]) == 1
+    @test length(tdh.lth_exs[2]) == 1
+    @test isempty(tdh.htl_exs[1])
+    @test isempty(tdh.htl_exs[2])
 
     #TODO
 end

--- a/test/integration/material_interface.jl
+++ b/test/integration/material_interface.jl
@@ -206,7 +206,7 @@ end
 
     randpos = rand(3, 4)
     tdh.chunks[2].storage.position .= randpos
-    Peridynamics.exchange_read_fields!(tdh, 1)
+    Peridynamics.exchange_loc_to_halo!(tdh, 1)
 
     @test b1.storage.position[:,1:2] ≈ [0.0 1.0; 0.0 0.0; 0.0 0.0]
     @test b1.storage.position[:,3:4] ≈ randpos[:,1:2]
@@ -234,7 +234,7 @@ end
     randbint = rand(3, 4)
     b2.storage.b_int .= randbint
     b1.storage.b_int .+= 1
-    Peridynamics.exchange_write_fields!(tdh, 1)
+    Peridynamics.exchange_halo_to_loc!(tdh, 1)
 
     @test b1.storage.position[:,1:2] ≈ [0.0 1.0; 0.0 0.0; 0.0 0.0]
     @test b1.storage.position[:,3:4] ≈ randpos[:,1:2]
@@ -260,7 +260,7 @@ end
     @test b2.storage.bond_active == [0, 0, 1, 0, 0, 1]
     @test b2.storage.n_active_bonds == [1, 1]
 
-    Peridynamics.exchange_write_fields!(tdh, 2)
+    Peridynamics.exchange_halo_to_loc!(tdh, 2)
 
     @test b1.storage.position[:,1:2] ≈ [0.0 1.0; 0.0 0.0; 0.0 0.0]
     @test b1.storage.position[:,3:4] ≈ randpos[:,1:2]

--- a/test/integration/material_interface.jl
+++ b/test/integration/material_interface.jl
@@ -135,26 +135,26 @@ end
     mat, vv = TestMaterial4(), VelocityVerlet(steps=1)
     @test Peridynamics.storage_type(mat, vv) == TestVerletStorage1
 
-    @test_throws ArgumentError Peridynamics.@halo_read_fields(TestVerletStorageNoSubtype,
+    @test_throws ArgumentError Peridynamics.@loc_to_halo_fields(TestVerletStorageNoSubtype,
                                                               :position)
 
-    @test_throws ArgumentError Peridynamics.@halo_read_fields(TestVerletStorage1,
+    @test_throws ArgumentError Peridynamics.@loc_to_halo_fields(TestVerletStorage1,
                                                               :randomfield)
 
-    Peridynamics.@halo_read_fields TestVerletStorage1 :position :displacement
-    @test hasmethod(Peridynamics.halo_read_fields, Tuple{TestVerletStorage1})
+    Peridynamics.@loc_to_halo_fields TestVerletStorage1 :position :displacement
+    @test hasmethod(Peridynamics.loc_to_halo_fields, Tuple{TestVerletStorage1})
     @test hasmethod(Peridynamics.is_halo_field, Tuple{TestVerletStorage1,Val{:position}})
     @test hasmethod(Peridynamics.is_halo_field,
                     Tuple{TestVerletStorage1,Val{:displacement}})
 
-    @test_throws ArgumentError Peridynamics.@halo_write_fields(TestVerletStorageNoSubtype,
+    @test_throws ArgumentError Peridynamics.@halo_to_loc_fields(TestVerletStorageNoSubtype,
                                                                :b_int)
 
-    @test_throws ArgumentError Peridynamics.@halo_write_fields(TestVerletStorage1,
+    @test_throws ArgumentError Peridynamics.@halo_to_loc_fields(TestVerletStorage1,
                                                                :randomfield)
 
-    Peridynamics.@halo_write_fields TestVerletStorage1 :b_int :b_ext
-    @test hasmethod(Peridynamics.halo_write_fields, Tuple{TestVerletStorage1})
+    Peridynamics.@halo_to_loc_fields TestVerletStorage1 :b_int :b_ext
+    @test hasmethod(Peridynamics.halo_to_loc_fields, Tuple{TestVerletStorage1})
     @test hasmethod(Peridynamics.is_halo_field, Tuple{TestVerletStorage1,Val{:b_int}})
     @test hasmethod(Peridynamics.is_halo_field, Tuple{TestVerletStorage1,Val{:b_ext}})
 end

--- a/test/integration/test_material.jl
+++ b/test/integration/test_material.jl
@@ -50,5 +50,5 @@ function TestVerletStorage(::TestMaterial, ::Peridynamics.VelocityVerlet,
                              n_active_bonds)
 end
 Peridynamics.@storage TestMaterial VelocityVerlet TestVerletStorage
-Peridynamics.@halo_read_fields TestVerletStorage :position
-Peridynamics.@halo_write_fields TestVerletStorage :b_int
+Peridynamics.@loc_to_halo_fields TestVerletStorage :position
+Peridynamics.@halo_to_loc_fields TestVerletStorage :b_int


### PR DESCRIPTION
The halo exchange functions now accept arbitrary storage fields.

####  Naming convention changed:
- `read_halo_exchange` $\Rightarrow$ `loc_to_halo_exchange`
- `write_halo_exchange` $\Rightarrow$`halo_to_loc_exchange`

#### New functions for `MPIDataHandler`
```julia
exchange_loc_to_halo!(dh::MPIDataHandler)
exchange_loc_to_halo!(dh::MPIDataHandler, fields::NTuple{N,Symbol}) where {N}
exchange_loc_to_halo!(dh::MPIDataHandler, field::Symbol)
exchange_halo_to_loc!(dh::MPIDataHandler)
exchange_halo_to_loc!(dh::MPIDataHandler, fields::NTuple{N,Symbol}) where {N}
exchange_halo_to_loc!(dh::MPIDataHandler, field::Symbol)
```

#### New functions for `ThreadsDataHandler`
```julia
exchange_loc_to_halo!(dh::ThreadsDataHandler, chunk_id::Int)
exchange_loc_to_halo!(dh::ThreadsDataHandler, chunk_id::Int, fields::NTuple{N,Symbol}) where {N}
exchange_loc_to_halo!(dh::ThreadsDataHandler, chunk_id::Int, field::Symbol)
exchange_halo_to_loc!(dh::ThreadsDataHandler, chunk_id::Int)
exchange_halo_to_loc!(dh::ThreadsDataHandler, chunk_id::Int, fields::NTuple{N,Symbol}) where {N}
exchange_halo_to_loc!(dh::ThreadsDataHandler, chunk_id::Int, field::Symbol)
```

Fixes #73 