### PR TITLE
Update bond_system.jl

### DIFF
--- a/src/discretization/bond_system.jl
+++ b/src/discretization/bond_system.jl
@@ -216,7 +216,7 @@ end
 @inline function stretch_based_failure!(storage::AbstractStorage, ::BondSystem,
                                         bond::Bond, params::AbstractPointParameters,
                                         ε::Float64, i::Int, bond_id::Int)
-    if ε > params.εc && bond.fail_permit
+    if abs(ε) > params.εc && bond.fail_permit
         storage.bond_active[bond_id] = false
     end
     storage.n_active_bonds[i] += storage.bond_active[bond_id]


### PR DESCRIPTION
I apologize for the confusion caused by the change. It seems that there are inconsistencies in the use of abs() to determine bond failure across different materials. I  believe that the original method, which does not involve abs(), is more physically accurate. I agree with your perspective on this issue. Please disregard the change that introduced abs() and stick with the original approach.