### PR TITLE
Add solver dependent storage macro

### DIFF
--- a/src/core/parameters.jl
+++ b/src/core/parameters.jl
@@ -47,6 +47,7 @@ end
 function macrocheck_input_material(material)
     material isa Symbol && return nothing
     (material isa Expr && material.head === :.) && return nothing
+    (material isa Expr && material.head === :escape) && return nothing
     return throw(ArgumentError("argument `$material` is not a valid material input!\n"))
 end
 


### PR DESCRIPTION
The macro `storage(material, storage)` is now extended with a macro `storage(material, solver, storage)`. This gives the possibility to create a custom time solver that requires new fields that are not added in the general storages.