### PR TITLE
Reusability of parameter definitions

### DIFF
--- a/src/core/parameters.jl
+++ b/src/core/parameters.jl
@@ -80,3 +80,24 @@ function constructor_check(::Type{Material}, ::Type{Param}) where {Material,Para
     end
     return nothing
 end
+
+struct StandardPointParameters <: AbstractPointParameters
+    δ::Float64
+    rho::Float64
+    E::Float64
+    nu::Float64
+    G::Float64
+    K::Float64
+    λ::Float64
+    μ::Float64
+    Gc::Float64
+    εc::Float64
+    bc::Float64
+end
+
+function StandardPointParameters(mat::AbstractMaterial, p::Dict{Symbol,Any})
+    (; δ, rho, E, nu, G, K, λ, μ) = get_required_point_parameters(mat, p)
+    (; Gc, εc) = get_frac_params(mat.dmgmodel, p, δ, K)
+    bc = 18 * K / (π * δ^4) # bond constant
+    return StandardPointParameters(δ, rho, E, nu, G, K, λ, μ, Gc, εc, bc)
+end

--- a/src/core/parameters.jl
+++ b/src/core/parameters.jl
@@ -2,10 +2,6 @@ function point_param_type(mat::AbstractMaterial)
     return throw(InterfaceError(mat, "point_param_type"))
 end
 
-function material_type(params::AbstractPointParameters)
-    return throw(InterfaceError(params, "material_type"))
-end
-
 function get_point_params(mat::AbstractMaterial, ::Dict{Symbol,Any})
     return throw(InterfaceError(mat, "get_point_params"))
 end
@@ -28,9 +24,6 @@ macro params(material, params)
     local _pointparam_type = quote
         Peridynamics.point_param_type(::$(esc(material))) = $(esc(params))
     end
-    local _material_type = quote
-        Peridynamics.material_type(::$(esc(params))) = $(esc(material))
-    end
     local _get_pointparams = quote
         function Peridynamics.get_point_params(m::$(esc(material)), p::Dict{Symbol,Any})
             return $(esc(params))(m, p)
@@ -39,8 +32,7 @@ macro params(material, params)
     local _post_checks = quote
         Peridynamics.constructor_check($(esc(material)), $(esc(params)))
     end
-    exprs = Expr(:block, _pre_checks, _pointparam_type, _material_type, _get_pointparams,
-                 _post_checks)
+    exprs = Expr(:block, _pre_checks, _pointparam_type, _get_pointparams, _post_checks)
     return exprs
 end
 

--- a/src/physics/fracture.jl
+++ b/src/physics/fracture.jl
@@ -117,6 +117,10 @@ function get_frac_params(::CriticalStretch, p::Dict{Symbol,Any}, δ::Float64, K:
     return (; Gc, εc)
 end
 
+function get_frac_params(::AbstractDamageModel, p, δ, K)
+    return (; )
+end
+
 function set_failure_permissions!(body::AbstractBody, set_name::Symbol,
                                   params::AbstractPointParameters)
     if has_fracture(body.mat, params)

--- a/src/physics/material_parameters.jl
+++ b/src/physics/material_parameters.jl
@@ -267,7 +267,7 @@ function log_param_property(::Val{:K}, param; indentation)
 end
 
 function Base.show(io::IO, @nospecialize(params::AbstractPointParameters))
-    print(io, "Parameters ", material_type(params), ": ")
+    print(io, "Parameters ", typeof(params), ": ")
     print(io, msg_fields_inline(params, (:δ, :E, :nu, :rho, :Gc)))
     return nothing
 end

--- a/src/physics/material_parameters.jl
+++ b/src/physics/material_parameters.jl
@@ -267,7 +267,7 @@ function log_param_property(::Val{:K}, param; indentation)
 end
 
 function Base.show(io::IO, @nospecialize(params::AbstractPointParameters))
-    print(io, "Parameters ", typeof(params), ": ")
+    print(io, typeof(params), ": ")
     print(io, msg_fields_inline(params, (:δ, :E, :nu, :rho, :Gc)))
     return nothing
 end

--- a/test/discretization/test_body.jl
+++ b/test/discretization/test_body.jl
@@ -16,7 +16,7 @@
     @test body.posdep_single_dim_ics == Vector{Peridynamics.PosDepSingleDimIC}()
     @test body.point_sets_precracks == Vector{Peridynamics.PointSetsPreCrack}()
     @test body.point_sets == Dict{Symbol,Vector{Int}}(:all_points => 1:n_points)
-    @test body.point_params == Vector{Peridynamics.StandardsPointParameters}()
+    @test body.point_params == Vector{Peridynamics.StandardPointParameters}()
     @test body.params_map == zeros(Int, n_points)
 end
 

--- a/test/discretization/test_body.jl
+++ b/test/discretization/test_body.jl
@@ -92,26 +92,29 @@ end
     # add material
     material!(body; horizon=1, E=1, rho=1, Gc=1)
     @test body.point_params == [
-        Peridynamics.BBPointParameters(1.0, 1.0, 1.0, 0.25, 0.4, 0.6666666666666666, 0.4,
-                                       0.4, 1.0, 0.9128709291752769, 3.819718634205488),
+        Peridynamics.StandardPointParameters(1.0, 1.0, 1.0, 0.25, 0.4, 0.6666666666666666,
+                                             0.4, 0.4, 1.0, 0.9128709291752769,
+                                             3.819718634205488),
     ]
     @test body.params_map == [1, 1, 1, 1]
 
     # add material to set
     material!(body, :a; horizon=2, E=2, rho=2, Gc=2)
     @test body.point_params == [
-        Peridynamics.BBPointParameters(1.0, 1.0, 1.0, 0.25, 0.4, 0.6666666666666666, 0.4,
-                                       0.4, 1.0, 0.9128709291752769, 3.819718634205488),
-        Peridynamics.BBPointParameters(2.0, 2.0, 2.0, 0.25, 0.8, 1.3333333333333333, 0.8,
-                                       0.8, 2.0, 0.6454972243679028, 0.477464829275686),
+        Peridynamics.StandardPointParameters(1.0, 1.0, 1.0, 0.25, 0.4, 0.6666666666666666,
+                                             0.4, 0.4, 1.0, 0.9128709291752769,
+                                             3.819718634205488),
+        Peridynamics.StandardPointParameters(2.0, 2.0, 2.0, 0.25, 0.8, 1.3333333333333333,
+                                             0.8, 0.8, 2.0, 0.6454972243679028,
+                                             0.477464829275686),
     ]
     @test body.params_map == [2, 2, 1, 1]
 
     # add material to body -> overwriting everything!
     material!(body; horizon=3, E=3, rho=3, Gc=3)
     @test body.point_params == [
-        Peridynamics.BBPointParameters(3.0, 3.0, 3.0, 0.25, 1.2, 2.0, 1.2, 1.2, 3.0,
-                                       0.5270462766947299, 0.1414710605261292),
+        Peridynamics.StandardPointParameters(3.0, 3.0, 3.0, 0.25, 1.2, 2.0, 1.2, 1.2, 3.0,
+                                             0.5270462766947299, 0.1414710605261292),
     ]
     @test body.params_map == [1, 1, 1, 1]
 end
@@ -213,8 +216,9 @@ end
     # add material
     material!(body; horizon=1, E=1, rho=1, Gc=1)
     @test body.point_params == [
-        Peridynamics.BBPointParameters(1.0, 1.0, 1.0, 0.25, 0.4, 0.6666666666666666, 0.4,
-                                       0.4, 1.0, 0.9128709291752769, 3.819718634205488),
+        Peridynamics.StandardPointParameters(1.0, 1.0, 1.0, 0.25, 0.4, 0.6666666666666666,
+                                             0.4, 0.4, 1.0, 0.9128709291752769,
+                                             3.819718634205488),
     ]
     @test body.params_map == [1, 1, 1, 1]
 
@@ -305,8 +309,9 @@ end
     # add material
     material!(body; horizon=1, E=1, rho=1, Gc=1)
     @test body.point_params == [
-        Peridynamics.BBPointParameters(1.0, 1.0, 1.0, 0.25, 0.4, 0.6666666666666666, 0.4,
-                                       0.4, 1.0, 0.9128709291752769, 3.819718634205488),
+        Peridynamics.StandardPointParameters(1.0, 1.0, 1.0, 0.25, 0.4, 0.6666666666666666,
+                                             0.4, 0.4, 1.0, 0.9128709291752769,
+                                             3.819718634205488),
     ]
     @test body.params_map == [1, 1, 1, 1]
 

--- a/test/discretization/test_body.jl
+++ b/test/discretization/test_body.jl
@@ -16,7 +16,7 @@
     @test body.posdep_single_dim_ics == Vector{Peridynamics.PosDepSingleDimIC}()
     @test body.point_sets_precracks == Vector{Peridynamics.PointSetsPreCrack}()
     @test body.point_sets == Dict{Symbol,Vector{Int}}(:all_points => 1:n_points)
-    @test body.point_params == Vector{Peridynamics.BBPointParameters}()
+    @test body.point_params == Vector{Peridynamics.StandardsPointParameters}()
     @test body.params_map == zeros(Int, n_points)
 end
 
@@ -36,7 +36,7 @@ end
     @test body.single_dim_ics == Vector{Peridynamics.SingleDimIC}()
     @test body.point_sets_precracks == Vector{Peridynamics.PointSetsPreCrack}()
     @test body.point_sets == Dict{Symbol,Vector{Int}}(:all_points => 1:n_points)
-    @test body.point_params == Vector{Peridynamics.BBPointParameters}()
+    @test body.point_params == Vector{Peridynamics.CKIPointParameters}()
     @test body.params_map == zeros(Int, n_points)
 end
 
@@ -81,7 +81,7 @@ end
     # test body creation
     @test body.mat == BBMaterial()
     @test body.n_points == n_points
-    @test body.point_params == Vector{Peridynamics.BBPointParameters}()
+    @test body.point_params == Vector{Peridynamics.StandardPointParameters}()
     @test body.params_map == zeros(Int, n_points)
     @test body.point_sets == Dict{Symbol,Vector{Int}}(:all_points => 1:n_points)
 

--- a/test/discretization/test_body_chunk.jl
+++ b/test/discretization/test_body_chunk.jl
@@ -93,7 +93,7 @@ end
     @test b1.storage.bond_active == [1, 0, 0, 1, 0, 0]
     @test b1.storage.n_active_bonds == [1, 1]
 
-    @test b1.paramsetup isa Peridynamics.BBPointParameters
+    @test b1.paramsetup isa Peridynamics.StandardPointParameters
     b1_params = Peridynamics.get_params(b1, 1)
     @test b1_params.δ ≈ 2.0
     @test b1_params.rho ≈ 1.0
@@ -156,7 +156,7 @@ end
     @test b2.storage.bond_active == [0, 0, 1, 0, 0, 1]
     @test b2.storage.n_active_bonds == [1, 1]
 
-    @test b2.paramsetup isa Peridynamics.BBPointParameters
+    @test b2.paramsetup isa Peridynamics.StandardPointParameters
     b2_params = Peridynamics.get_params(b2, 1)
     @test b2_params.δ ≈ 2.0
     @test b2_params.rho ≈ 1.0
@@ -245,7 +245,7 @@ end
     @test length(b1.paramsetup.parameters) == 2
 
     pp1 = Peridynamics.get_params(b1, 1)
-    @test pp1 isa Peridynamics.BBPointParameters
+    @test pp1 isa Peridynamics.StandardPointParameters
     @test pp1.δ ≈ 2.0
     @test pp1.rho ≈ 1.0
     @test pp1.E ≈ 1.0
@@ -259,7 +259,7 @@ end
     @test pp1.bc ≈ 0.238732414637843
 
     pp2 = Peridynamics.get_params(b1, 2)
-    @test pp2 isa Peridynamics.BBPointParameters
+    @test pp2 isa Peridynamics.StandardPointParameters
     @test pp2.δ ≈ 2.0
     @test pp2.rho ≈ 1.0
     @test pp2.E ≈ 1.0
@@ -273,7 +273,7 @@ end
     @test pp2.bc ≈ 0.238732414637843
 
     pp3 = Peridynamics.get_params(b1, 3)
-    @test pp3 isa Peridynamics.BBPointParameters
+    @test pp3 isa Peridynamics.StandardPointParameters
     @test pp3.δ ≈ 3.0
     @test pp3.rho ≈ 2.0
     @test pp3.E ≈ 2.0
@@ -287,7 +287,7 @@ end
     @test pp3.bc ≈ 0.0943140403507528
 
     pp4= Peridynamics.get_params(b1, 4)
-    @test pp4 isa Peridynamics.BBPointParameters
+    @test pp4 isa Peridynamics.StandardPointParameters
     @test pp4.δ ≈ 3.0
     @test pp4.rho ≈ 2.0
     @test pp4.E ≈ 2.0
@@ -350,7 +350,7 @@ end
     @test length(b2.paramsetup.parameters) == 2
 
     pp3 = Peridynamics.get_params(b2, 1)
-    @test pp3 isa Peridynamics.BBPointParameters
+    @test pp3 isa Peridynamics.StandardPointParameters
     @test pp3.δ ≈ 3.0
     @test pp3.rho ≈ 2.0
     @test pp3.E ≈ 2.0
@@ -364,7 +364,7 @@ end
     @test pp3.bc ≈ 0.0943140403507528
 
     pp4 = Peridynamics.get_params(b2, 2)
-    @test pp4 isa Peridynamics.BBPointParameters
+    @test pp4 isa Peridynamics.StandardPointParameters
     @test pp4.δ ≈ 3.0
     @test pp4.rho ≈ 2.0
     @test pp4.E ≈ 2.0
@@ -378,7 +378,7 @@ end
     @test pp4.bc ≈ 0.0943140403507528
 
     pp1 = Peridynamics.get_params(b2, 3)
-    @test pp1 isa Peridynamics.BBPointParameters
+    @test pp1 isa Peridynamics.StandardPointParameters
     @test pp1.δ ≈ 2.0
     @test pp1.rho ≈ 1.0
     @test pp1.E ≈ 1.0
@@ -392,7 +392,7 @@ end
     @test pp1.bc ≈ 0.238732414637843
 
     pp2 = Peridynamics.get_params(b2, 4)
-    @test pp2 isa Peridynamics.BBPointParameters
+    @test pp2 isa Peridynamics.StandardPointParameters
     @test pp2.δ ≈ 2.0
     @test pp2.rho ≈ 1.0
     @test pp2.E ≈ 1.0

--- a/test/integration/material_interface.jl
+++ b/test/integration/material_interface.jl
@@ -20,8 +20,8 @@ end
 @testitem "Point parameters declaration" begin
     import Peridynamics: AbstractBondSystemMaterial, NoCorrection, AbstractPointParameters,
                          InterfaceError, typecheck_params, constructor_check,
-                         point_param_type, material_type, get_point_params,
-                         macrocheck_input_material, macrocheck_input_params
+                         point_param_type, get_point_params, macrocheck_input_material,
+                         macrocheck_input_params
     struct TestMaterial2 <: AbstractBondSystemMaterial{NoCorrection} end
     struct TestPointParameters2 <: AbstractPointParameters
         δ::Float64
@@ -41,8 +41,6 @@ end
     @test isnothing(typecheck_params(TestMaterial2, TestPointParameters2))
     ie1 = InterfaceError(TestMaterial2, "point_param_type")
     @test_throws ie1 point_param_type(TestMaterial2())
-    ie2 = InterfaceError(TestPointParameters2, "material_type")
-    @test_throws ie2 material_type(tpp2)
     ie3 = InterfaceError(TestMaterial2, "get_point_params")
     @test_throws ie3 get_point_params(TestMaterial2(), Dict{Symbol,Any}())
 

--- a/test/physics/test_material_parameters.jl
+++ b/test/physics/test_material_parameters.jl
@@ -223,7 +223,7 @@ end
 
 @testitem "log_param_property" begin
     p = Dict{Symbol,Any}(:E => 1, :nu => 0.25, :rho => 1, :horizon => 1)
-    param = Peridynamics.BBPointParameters(BBMaterial(), p)
+    param = Peridynamics.get_point_params(BBMaterial(), p)
     msg = Peridynamics.log_param_property(Val(:randomthing), param; indentation=0)
     @test msg == ""
     msg = Peridynamics.log_param_property(Val(:δ), param; indentation=0)


### PR DESCRIPTION
Removing the `material_type` function makes it possible to reuse point parameter definitions with other materials.