### PR TITLE
Fix broken example block in docstring

### DIFF
--- a/src/core/storages.jl
+++ b/src/core/storages.jl
@@ -57,7 +57,7 @@ Example definition of the storage for the bond-based material:
     bond_active::Vector{Bool}
     @pointfield n_active_bonds::Vector{Int}
 end
-
+````
 """
 macro storage end
 


### PR DESCRIPTION
Corrects the mistake in the private `@storage`-docstring where an example block had no ending. (close #212)