### PR TITLE
Added the dual-horizon bond-based formulation

### DIFF
--- a/docs/src/public_api_reference.md
+++ b/docs/src/public_api_reference.md
@@ -11,6 +11,7 @@ Pages = ["public_api_reference.md"]
 ## Material models
 ```@docs
 BBMaterial
+DHBBMaterial
 OSBMaterial
 CMaterial
 CRMaterial

--- a/src/Peridynamics.jl
+++ b/src/Peridynamics.jl
@@ -9,7 +9,8 @@ end
 import LibGit2, Dates
 
 # Material models
-export BBMaterial, OSBMaterial, CMaterial, CRMaterial, BACMaterial, CKIMaterial
+export BBMaterial, DHBBMaterial, OSBMaterial, CMaterial, CRMaterial, BACMaterial,
+       CKIMaterial
 
 # CMaterial related types
 export LinearElastic, NeoHooke, MooneyRivlin, SaintVenantKirchhoff, ZEMSilling
@@ -75,6 +76,7 @@ abstract type AbstractCorrection end
 abstract type AbstractStorage end
 abstract type AbstractCondition end
 abstract type AbstractBondSystemMaterial{Correction} <: AbstractMaterial end
+abstract type AbstractBondBasedMaterial{CM} <: AbstractBondSystemMaterial{CM} end
 abstract type AbstractCorrespondenceMaterial{CM,ZEM} <: AbstractBondSystemMaterial{ZEM} end
 abstract type AbstractBondAssociatedSystemMaterial <: AbstractMaterial end
 abstract type AbstractConstitutiveModel end
@@ -132,6 +134,7 @@ include("time_solvers/velocity_verlet.jl")
 include("time_solvers/dynamic_relaxation.jl")
 
 include("physics/bond_based.jl")
+include("physics/dh_bond_based.jl")
 include("physics/continuum_kinematics_inspired.jl")
 include("physics/ordinary_state_based.jl")
 include("physics/constitutive_models.jl")

--- a/test/integration/b_int_dh_bond_based.jl
+++ b/test/integration/b_int_dh_bond_based.jl
@@ -1,0 +1,90 @@
+@testitem "Internal force density dual-horizon bond based" begin
+    ref_position = [0.0 1.0; 0.0 0.0; 0.0 0.0]
+    volume = [1.0, 1.0]
+    δ = 1.5
+    E = 210e9
+    body = Body(DHBBMaterial(), ref_position, volume)
+    material!(body; horizon=δ, rho=1, E)
+    no_failure!(body)
+
+    dh = Peridynamics.threads_data_handler(body, VelocityVerlet(steps=1), 1)
+    chunk = dh.chunks[1]
+    (; position, b_int) = chunk.storage
+    (; bonds) = chunk.system
+
+    @test position == ref_position
+    @test b_int == zeros(3, 2)
+
+    # Boundary Condition:
+    # Point 2 with v_z = 1 m/s with Δt = 0.0015 s
+    position[1, 2] = 1.0015
+
+    Peridynamics.calc_force_density!(chunk, 0, 0)
+
+    b12 = 18 * E / (3 * (1 - 2 * 0.25)) / (π * δ^4) * 1.0015 * 0.0015/1.0015 * 1.0
+    @test b_int ≈ [b12 -b12; 0.0 0.0; 0.0 0.0]
+end
+
+@testitem "Internal force density dual-horizon bond based with surface correction" begin
+    ref_position = [0.0 1.0; 0.0 0.0; 0.0 0.0]
+    volume = [1.0, 1.0]
+    δ = 1.5
+    E = 210e9
+    body = Body(DHBBMaterial{EnergySurfaceCorrection}(), ref_position, volume)
+    material!(body; horizon=δ, rho=1, E)
+    no_failure!(body)
+
+    ts = VelocityVerlet(steps=1)
+    dh = Peridynamics.threads_data_handler(body, ts, 1)
+    Peridynamics.initialize!(dh, ts)
+    chunk = dh.chunks[1]
+    (; position, b_int) = chunk.storage
+    (; bonds) = chunk.system
+
+    @test position == ref_position
+    @test b_int == zeros(3, 2)
+
+    # Boundary Condition:
+    # Point 2 with v_z = 1 m/s with Δt = 0.0015 s
+    position[1, 2] = 1.0015
+
+    Peridynamics.calc_force_density!(chunk, 0, 0)
+
+    sc = 2 * 3.1808625617603665 # double the normal surface correction factor
+    @test all(x -> x ≈ sc, chunk.system.correction.scfactor)
+
+    b12 = sc * 18 * E / (3 * (1 - 2 * 0.25)) / (π * δ^4) * 1.0015 * 0.0015/1.0015 * 1.0
+    @test b_int ≈ [b12 -b12; 0.0 0.0; 0.0 0.0]
+end
+
+@testitem "Internal force density dual-horizon bond based interface" begin
+    ref_position = [0.0 1.0; 0.0 0.0; 0.0 0.0]
+    volume = [1.0, 1.0]
+    δ = 1.5
+    Ea = 105e9
+    Eb = 2 * Ea
+    E = (Ea + Eb) / 2
+    body = Body(DHBBMaterial(), ref_position, volume)
+    point_set!(body, :a, [1])
+    point_set!(body, :b, [2])
+    material!(body, :a, horizon=δ, rho=1, E=Ea, Gc=1.0)
+    material!(body, :b, horizon=δ, rho=1, E=Eb, Gc=1.0)
+    no_failure!(body)
+
+    dh = Peridynamics.threads_data_handler(body, VelocityVerlet(steps=1), 1)
+    chunk = dh.chunks[1]
+    (; position, b_int) = chunk.storage
+    (; bonds) = chunk.system
+
+    @test position == ref_position
+    @test b_int == zeros(3, 2)
+
+    # Boundary Condition:
+    # Point 2 with v_z = 1 m/s with Δt = 0.0015 s
+    position[1, 2] = 1.0015
+
+    Peridynamics.calc_force_density!(chunk, 0, 0)
+
+    b12 = 18 * E / (3 * (1 - 2 * 0.25)) / (π * δ^4) * 1.0015 * 0.0015/1.0015 * 1.0
+    @test b_int ≈ [b12 -b12; 0.0 0.0; 0.0 0.0]
+end


### PR DESCRIPTION
Added the dual-horizon peridynamics approach for the bond-based formulation. See https://doi.org/10.1002/nme.5257 for further information on the dual-horizon peridynamics approach.