### PR TITLE
Fix MPI tests with updated project directory specification

### DIFF
--- a/test/core/test_halo_exchange.jl
+++ b/test/core/test_halo_exchange.jl
@@ -316,7 +316,10 @@ end
         @test dh.chunk.storage.b_int[:,3:4] ≈ randbint[:,1:2]
     end
     """
-    cmd = `$(Peridynamics.MPI.mpiexec()) -n 2 $(Base.julia_cmd()) --project -e $(mpi_cmd)`
+    mpiexec = Peridynamics.MPI.mpiexec()
+    jlcmd = Base.julia_cmd()
+    pdir = normpath(joinpath(@__DIR__, "..", ".."))
+    cmd = `$(mpiexec) -n 2 $(jlcmd) --project=$(pdir) -e $(mpi_cmd)`
     @test success(cmd) # does not print anything
     # for debugging use the run command:
     # run(cmd)
@@ -363,7 +366,10 @@ end
         @test dh.chunk.storage.position[:,1:2] ≈ position[:,1:2] + randpos[:,3:4]
     end
     """
-    cmd = `$(Peridynamics.MPI.mpiexec()) -n 2 $(Base.julia_cmd()) --project -e $(mpi_cmd)`
+    mpiexec = Peridynamics.MPI.mpiexec()
+    jlcmd = Base.julia_cmd()
+    pdir = normpath(joinpath(@__DIR__, "..", ".."))
+    cmd = `$(mpiexec) -n 2 $(jlcmd) --project=$(pdir) -e $(mpi_cmd)`
     @test success(cmd) # does not print anything
     # for debugging use the run command:
     # run(cmd)

--- a/test/integration/mpi_threads_comparison.jl
+++ b/test/integration/mpi_threads_comparison.jl
@@ -47,7 +47,10 @@
     end
     sim_bb(30, "$path_mpi")
     """
-    run(`$(Peridynamics.MPI.mpiexec()) -n 2 $(Base.julia_cmd()) --project -e $(mpi_cmd)`)
+    mpiexec = Peridynamics.MPI.mpiexec()
+    jlcmd = Base.julia_cmd()
+    pdir = normpath(joinpath(@__DIR__, "..", ".."))
+    run(`$(mpiexec) -n 2 $(jlcmd) --project=$(pdir) -e $(mpi_cmd)`)
 
     @test isdir(path_threads_vtk)
     @test isdir(path_mpi_vtk)
@@ -112,7 +115,10 @@ end
     end
     sim_bb(30, "$path_mpi")
     """
-    run(`$(Peridynamics.MPI.mpiexec()) -n 2 $(Base.julia_cmd()) --project -e $(mpi_cmd)`)
+    mpiexec = Peridynamics.MPI.mpiexec()
+    jlcmd = Base.julia_cmd()
+    pdir = normpath(joinpath(@__DIR__, "..", ".."))
+    run(`$(mpiexec) -n 2 $(jlcmd) --project=$(pdir) -e $(mpi_cmd)`)
 
     @test isdir(path_threads_vtk)
     @test isdir(path_mpi_vtk)
@@ -182,7 +188,10 @@ end
     end
     sim_bb(30, "$path_mpi")
     """
-    run(`$(Peridynamics.MPI.mpiexec()) -n 2 $(Base.julia_cmd()) --project -e $(mpi_cmd)`)
+    mpiexec = Peridynamics.MPI.mpiexec()
+    jlcmd = Base.julia_cmd()
+    pdir = normpath(joinpath(@__DIR__, "..", ".."))
+    run(`$(mpiexec) -n 2 $(jlcmd) --project=$(pdir) -e $(mpi_cmd)`)
 
     @test isdir(path_threads_vtk)
     @test isdir(path_mpi_vtk)
@@ -247,7 +256,10 @@ end
     end
     sim_osb(30, "$path_mpi")
     """
-    run(`$(Peridynamics.MPI.mpiexec()) -n 2 $(Base.julia_cmd()) --project -e $(mpi_cmd)`)
+    mpiexec = Peridynamics.MPI.mpiexec()
+    jlcmd = Base.julia_cmd()
+    pdir = normpath(joinpath(@__DIR__, "..", ".."))
+    run(`$(mpiexec) -n 2 $(jlcmd) --project=$(pdir) -e $(mpi_cmd)`)
 
     @test isdir(path_threads_vtk)
     @test isdir(path_mpi_vtk)
@@ -312,7 +324,10 @@ end
     end
     sim_cc(30, "$path_mpi")
     """
-    run(`$(Peridynamics.MPI.mpiexec()) -n 2 $(Base.julia_cmd()) --project -e $(mpi_cmd)`)
+    mpiexec = Peridynamics.MPI.mpiexec()
+    jlcmd = Base.julia_cmd()
+    pdir = normpath(joinpath(@__DIR__, "..", ".."))
+    run(`$(mpiexec) -n 2 $(jlcmd) --project=$(pdir) -e $(mpi_cmd)`)
 
     @test isdir(path_threads_vtk)
     @test isdir(path_mpi_vtk)
@@ -378,7 +393,10 @@ end
     end
     sim_bac(30, "$path_mpi")
     """
-    run(`$(Peridynamics.MPI.mpiexec()) -n 2 $(Base.julia_cmd()) --project -e $(mpi_cmd)`)
+    mpiexec = Peridynamics.MPI.mpiexec()
+    jlcmd = Base.julia_cmd()
+    pdir = normpath(joinpath(@__DIR__, "..", ".."))
+    run(`$(mpiexec) -n 2 $(jlcmd) --project=$(pdir) -e $(mpi_cmd)`)
 
     @test isdir(path_threads_vtk)
     @test isdir(path_mpi_vtk)


### PR DESCRIPTION
Fixed the errors when using `@testitem`s in VSCode and MPI tests. Now the project path to the main `Project.toml` is properly specified.