### PR TITLE
Automatic `dev` with documentation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,6 +57,11 @@ jobs:
           version: '1'
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
+      - run: |
+          julia --project=docs -e '
+            using Pkg;
+            Pkg.develop(PackageSpec(path=pwd()));
+            Pkg.instantiate()' 
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/servedocs.jl
+++ b/docs/servedocs.jl
@@ -6,8 +6,9 @@
 const REPO_ROOT = dirname(@__DIR__)
 
 # Make sure the docs environment is active and instantiated
-import Pkg
+using Pkg
 Pkg.activate(@__DIR__)
+Pkg.develop(PackageSpec(path=REPO_ROOT))
 Pkg.instantiate()
 
 # Communicate with make.jl that docs are build in live mode


### PR DESCRIPTION
The package is now automatically added via `dev` when building documentation.